### PR TITLE
Capitalized entries in .proto file resulted in the record name being overwritten

### DIFF
--- a/src/pokemon_pb.erl
+++ b/src/pokemon_pb.erl
@@ -142,9 +142,9 @@ to_record(pikachu, DecodedTuples) ->
 set_record_field(Fields, Record, Field, Value) ->
     Index = list_index(Field, Fields),
     erlang:setelement(Index+1, Record, Value).
-    
+
 list_index(Target, List) -> list_index(Target, List, 1).
 
 list_index(Target, [Target|_], Index) -> Index;
 list_index(Target, [_|Tail], Index) -> list_index(Target, Tail, Index+1);
-list_index(_, [], _) -> 0.
+list_index(_, [], _) -> -1.

--- a/src/protobuffs_compile.erl
+++ b/src/protobuffs_compile.erl
@@ -273,7 +273,7 @@ filter_decode_clause(Msgs, {MsgName, Fields}, {clause,L,_Args,Guards,[_,B,C]}) -
 				 {FNum,Tag,SType,SName,_} <- Fields]),
     Cons = lists:foldl(
 	     fun({FNum, FName, Type, Opts}, Acc) ->
-		     {cons,L,{tuple,L,[{integer,L,FNum},{atom,L,FName},{atom,L,Type},erl_parse:abstract(Opts)]},Acc}
+             {cons,L,{tuple,L,[{integer,L,FNum},{atom,L,list_to_atom(string:to_lower(atom_to_list(FName)))},{atom,L,Type},erl_parse:abstract(Opts)]},Acc}
 	     end, {nil,L}, Types),
     A = {match,L,{var,L,'Types'},Cons},
     C1 = replace_atom(C, pikachu, atomize(MsgName)),


### PR DESCRIPTION
Capitalized entries in .proto file resulted in the record name being
overwritten.  For example given the protobuf file

message WithCaps {
  optional string nocaps = 1;
  optional string CAPS = 2;
}

if you compile and run without the patch, you get something like

1> rr(caps_pb).
[withcaps]
2> caps_pb:encode(#withcaps{caps="hello"}).
<<18,5,104,101,108,108,111>>
3> caps_pb:decode_withcaps(v(2)).
{"hello",undefined,undefined}

This fixes this in 2 ways.

First when determining the index, the not found case returns -1 instead of 0,
so it should be impossible to overwrite the record name, and you get a bad
argument exception.

Second the field is lowercased in the lookup table in the decode function.

Now the above works.

1> rr(caps_pb).
[withcaps]
2> caps_pb:encode(#withcaps{caps="hello"}).
<<18,5,104,101,108,108,111>>
3> caps_pb:decode_withcaps(v(2)).
