### PR TITLE
Guard each record against multiple definitions.

### DIFF
--- a/src/protobuffs_compile.erl
+++ b/src/protobuffs_compile.erl
@@ -718,7 +718,7 @@ write_header_include_file(Basename, Messages) ->
     [begin
          OutFields = [{string:to_lower(A), Optional, Default} || {_, Optional, _, A, Default} <- lists:keysort(1, Fields)],
          DefName = string:to_upper(Name) ++ "_PB_H",
-         protobuffs_file:format(FileRef, "ifndef(~s).~n-define(~s, true).~n", [DefName, DefName]),
+         protobuffs_file:format(FileRef, "-ifndef(~s).~n-define(~s, true).~n", [DefName, DefName]),
          protobuffs_file:format(FileRef, "-record(~s, {~n    ", [string:to_lower(Name)]),
          WriteFields0 = generate_field_definitions(OutFields),
          WriteFields = case Extends of


### PR DESCRIPTION
This helps in the case where an "import" directive is used in the .proto file and source files include both the parent and the child headers, or include multiple headers that import the same parent.

NOTE: This is a reapplication of the commit from #12 and supersedes it. It has been rebased atop the upstream changes that were merged into master.

There are minor whitespace changes to the changed function.
