### PR TITLE
Remove compile warnings, add specs and cleanup whitespace

### DIFF
--- a/src/protobuffs.erl
+++ b/src/protobuffs.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2009 
+%% Copyright (c) 2009
 %% Nick Gerakines <nick@gerakines.net>
 %% Jacob Vorreuter <jacob.vorreuter@gmail.com>
 %%
@@ -45,22 +45,22 @@
 -define(TYPE_32BIT, 5).
 
 -type encoded_field_type() ::
-	?TYPE_VARINT | ?TYPE_64BIT | ?TYPE_STRING |
-	?TYPE_START_GROUP | ?TYPE_END_GROUP | ?TYPE_32BIT.
+        ?TYPE_VARINT | ?TYPE_64BIT | ?TYPE_STRING |
+        ?TYPE_START_GROUP | ?TYPE_END_GROUP | ?TYPE_32BIT.
 
--type field_type() :: bool | enum | int32 | uint32 | int64 | 
-		      unit64 | sint32 | sint64 | fixed32 | 
-		      sfixed32 | fixed64 | sfixed64 | string | 
-		      bytes | float | double.
+-type field_type() :: bool | enum | int32 | uint32 | int64 |
+                      unit64 | sint32 | sint64 | fixed32 |
+                      sfixed32 | fixed64 | sfixed64 | string |
+                      bytes | float | double.
 
 %%--------------------------------------------------------------------
 %% @doc Encode an Erlang data structure into a Protocol Buffers value.
 %% @end
 %%--------------------------------------------------------------------
 -spec encode(FieldID :: non_neg_integer(),
-	     Value :: any(),
-	     Type :: field_type()) -> 
-		    binary().
+             Value :: any(),
+             Type :: field_type()) ->
+                    binary().
 encode(FieldID, Value, Type) ->
     iolist_to_binary(encode_internal(FieldID, Value, Type)).
 
@@ -68,73 +68,73 @@ encode(FieldID, Value, Type) ->
 %% @doc Encode an list of Erlang data structure into a Protocol Buffers values.
 %% @end
 %%--------------------------------------------------------------------
--spec encode_packed(FieldID :: non_neg_integer(), 
-		    Values :: list(), 
-		    Type :: field_type()) -> 
-			   binary().
+-spec encode_packed(FieldID :: non_neg_integer(),
+                    Values :: list(),
+                    Type :: field_type()) ->
+                           binary().
 encode_packed(_FieldID, [], _Type) ->
     <<>>;
 encode_packed(FieldID, Values, Type) ->
     PackedValues = iolist_to_binary(encode_packed_internal(Values,Type,[])),
     Size = encode_varint(size(PackedValues)),
     iolist_to_binary([encode_field_tag(FieldID, ?TYPE_STRING),Size,PackedValues]).
-    
+
 %% @hidden
--spec encode_internal(FieldID :: non_neg_integer(), 
-		      Value :: any(), 
-		      Type :: field_type()) -> 
-			     iolist().
+-spec encode_internal(FieldID :: non_neg_integer(),
+                      Value :: any(),
+                      Type :: field_type()) ->
+                             iolist().
 encode_internal(FieldID, false, bool) ->
     encode_internal(FieldID, 0, int32);
 encode_internal(FieldID, true, bool) ->
     encode_internal(FieldID, 1, int32);
 encode_internal(FieldID, Integer, enum) when is_integer(Integer) ->
     encode_internal(FieldID, Integer, int32);
-encode_internal(FieldID, Integer, int32) when Integer >= -16#80000000, 
-					      Integer < 0 ->
+encode_internal(FieldID, Integer, int32) when Integer >= -16#80000000,
+                                              Integer < 0 ->
     encode_internal(FieldID, Integer, int64);
-encode_internal(FieldID, Integer, int64) when Integer >= -16#8000000000000000, 
-					      Integer < 0 ->
+encode_internal(FieldID, Integer, int64) when Integer >= -16#8000000000000000,
+                                              Integer < 0 ->
     encode_internal(FieldID, Integer + (1 bsl 64), uint64);
-encode_internal(FieldID, Integer, int32) when is_integer(Integer), 
-					      Integer >= -16#80000000, 
-					      Integer =< 16#7fffffff ->
+encode_internal(FieldID, Integer, int32) when is_integer(Integer),
+                                              Integer >= -16#80000000,
+                                              Integer =< 16#7fffffff ->
     encode_varint_field(FieldID, Integer);
 encode_internal(FieldID, Integer, uint32) when Integer band 16#ffffffff =:= Integer ->
-    encode_varint_field(FieldID, Integer);    
-encode_internal(FieldID, Integer, int64) when is_integer(Integer), 
-					      Integer >= -16#8000000000000000, 
-					      Integer =< 16#7fffffffffffffff ->
+    encode_varint_field(FieldID, Integer);
+encode_internal(FieldID, Integer, int64) when is_integer(Integer),
+                                              Integer >= -16#8000000000000000,
+                                              Integer =< 16#7fffffffffffffff ->
     encode_varint_field(FieldID, Integer);
 encode_internal(FieldID, Integer, uint64) when Integer band 16#ffffffffffffffff =:= Integer ->
     encode_varint_field(FieldID, Integer);
 encode_internal(FieldID, Integer, bool) when Integer =:= 1; Integer =:= 0 ->
     encode_varint_field(FieldID, Integer);
-encode_internal(FieldID, Integer, sint32) when is_integer(Integer), 
-					       Integer >= -16#80000000, 
-					       Integer < 0 ->
+encode_internal(FieldID, Integer, sint32) when is_integer(Integer),
+                                               Integer >= -16#80000000,
+                                               Integer < 0 ->
     encode_varint_field(FieldID, bnot (Integer bsl 1));
-encode_internal(FieldID, Integer, sint64) when is_integer(Integer), 
-					       Integer >= -16#8000000000000000, 
-					       Integer < 0 ->
+encode_internal(FieldID, Integer, sint64) when is_integer(Integer),
+                                               Integer >= -16#8000000000000000,
+                                               Integer < 0 ->
     encode_varint_field(FieldID, bnot (Integer bsl 1));
-encode_internal(FieldID, Integer, sint32) when is_integer(Integer), 
-					       Integer >= 0, 
-					       Integer =< 16#7fffffff ->
+encode_internal(FieldID, Integer, sint32) when is_integer(Integer),
+                                               Integer >= 0,
+                                               Integer =< 16#7fffffff ->
     encode_varint_field(FieldID, Integer bsl 1);
-encode_internal(FieldID, Integer, sint64) when is_integer(Integer), 
-					       Integer >= 0, 
-					       Integer =< 16#7fffffffffffffff ->
+encode_internal(FieldID, Integer, sint64) when is_integer(Integer),
+                                               Integer >= 0,
+                                               Integer =< 16#7fffffffffffffff ->
     encode_varint_field(FieldID, Integer bsl 1);
 encode_internal(FieldID, Integer, fixed32) when Integer band 16#ffffffff =:= Integer ->
     [encode_field_tag(FieldID, ?TYPE_32BIT), <<Integer:32/little-integer>>];
-encode_internal(FieldID, Integer, sfixed32) when Integer >= -16#80000000, 
-						 Integer =< 16#7fffffff ->
+encode_internal(FieldID, Integer, sfixed32) when Integer >= -16#80000000,
+                                                 Integer =< 16#7fffffff ->
     [encode_field_tag(FieldID, ?TYPE_32BIT), <<Integer:32/little-integer>>];
 encode_internal(FieldID, Integer, fixed64) when Integer band 16#ffffffffffffffff =:= Integer ->
     [encode_field_tag(FieldID, ?TYPE_64BIT), <<Integer:64/little-integer>>];
 encode_internal(FieldID, Integer, sfixed64) when Integer >= -16#8000000000000000,
-						 Integer =< 16#7fffffffffffffff ->
+                                                 Integer =< 16#7fffffffffffffff ->
     [encode_field_tag(FieldID, ?TYPE_64BIT), <<Integer:64/little-integer>>];
 encode_internal(FieldID, String, string) when is_list(String) ->
     encode_internal(FieldID, unicode:characters_to_binary(String), string);
@@ -169,10 +169,10 @@ encode_internal(FieldID, Value, Type) ->
 
 
 %% @hidden
--spec encode_packed_internal(Values :: list(), 
-			     ExpectedType :: field_type(),
-			     Acc :: list()) ->
-				    iolist().
+-spec encode_packed_internal(Values :: list(),
+                             ExpectedType :: field_type(),
+                             Acc :: list()) ->
+                                    iolist().
 encode_packed_internal([],_Type,Acc) ->
     lists:reverse(Acc);
 encode_packed_internal([Value|Tail], ExpectedType, Acc) ->
@@ -184,35 +184,35 @@ encode_packed_internal([Value|Tail], ExpectedType, Acc) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec read_field_num_and_wire_type(Bytes :: binary()) ->
-					  {{non_neg_integer(), encoded_field_type()}, binary()}.
+                                          {{non_neg_integer(), encoded_field_type()}, binary()}.
 read_field_num_and_wire_type(<<_:8,_/binary>> = Bytes) ->
     {Tag, Rest} = decode_varint(Bytes),
     FieldID = Tag bsr 3,
     case Tag band 7 of
-	?TYPE_VARINT ->
-	    {{FieldID, ?TYPE_VARINT}, Rest};
-	?TYPE_64BIT ->
-	    {{FieldID, ?TYPE_64BIT}, Rest};
-	?TYPE_STRING ->
-	    {{FieldID, ?TYPE_STRING}, Rest};
-	?TYPE_START_GROUP ->
-	    {{FieldID, ?TYPE_START_GROUP}, Rest};
-	?TYPE_END_GROUP ->
-	    {{FieldID, ?TYPE_END_GROUP}, Rest};
-	?TYPE_32BIT ->
-	    {{FieldID, ?TYPE_32BIT}, Rest};
-	_Else ->
-	    erlang:throw({error, "Error decodeing type"})
+        ?TYPE_VARINT ->
+            {{FieldID, ?TYPE_VARINT}, Rest};
+        ?TYPE_64BIT ->
+            {{FieldID, ?TYPE_64BIT}, Rest};
+        ?TYPE_STRING ->
+            {{FieldID, ?TYPE_STRING}, Rest};
+        ?TYPE_START_GROUP ->
+            {{FieldID, ?TYPE_START_GROUP}, Rest};
+        ?TYPE_END_GROUP ->
+            {{FieldID, ?TYPE_END_GROUP}, Rest};
+        ?TYPE_32BIT ->
+            {{FieldID, ?TYPE_32BIT}, Rest};
+        _Else ->
+            erlang:throw({error, "Error decodeing type"})
     end;
 read_field_num_and_wire_type(Bytes) ->
     erlang:error(badarg,[Bytes]).
-    
+
 %%--------------------------------------------------------------------
 %% @doc Decode a single value from a protobuffs data structure
 %% @end
 %%--------------------------------------------------------------------
 -spec decode(Bytes :: binary(), ExpectedType :: field_type()) ->
-		    {{non_neg_integer(), any()}, binary()}.
+                    {{non_neg_integer(), any()}, binary()}.
 decode(Bytes, ExpectedType) ->
     {{FieldID, WireType}, Rest} = read_field_num_and_wire_type(Bytes),
     {Value, Rest1} = decode_value(Rest, WireType, ExpectedType),
@@ -223,16 +223,16 @@ decode(Bytes, ExpectedType) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec decode_packed(Bytes :: binary(), ExpectedType :: field_type()) ->
-			   {{non_neg_integer(), any()}, binary()}.
+                           {{non_neg_integer(), any()}, binary()}.
 decode_packed(Bytes, ExpectedType) ->
     case read_field_num_and_wire_type(Bytes) of
-	{{FieldID, ?TYPE_STRING}, Rest} ->
-	    {Length, Rest1} = decode_varint(Rest),
-	    {Packed,Rest2} = split_binary(Rest1, Length),
-	    Values = decode_packed_values(Packed, ExpectedType, []),
-	    {{FieldID, Values},Rest2};
-	_Else ->
-	    erlang:error(badarg)
+        {{FieldID, ?TYPE_STRING}, Rest} ->
+            {Length, Rest1} = decode_varint(Rest),
+            {Packed,Rest2} = split_binary(Rest1, Length),
+            Values = decode_packed_values(Packed, ExpectedType, []),
+            {{FieldID, Values},Rest2};
+        _Else ->
+            erlang:error(badarg)
     end.
 
 %%--------------------------------------------------------------------
@@ -266,11 +266,11 @@ skip_next_field(Bytes) ->
     end,
     {ok, Rest1}.
 
-%% @hidden    
+%% @hidden
 -spec decode_packed_values(Bytes :: binary(),
-			   Type :: field_type(),
-			   Acc :: list()) ->
-				  iolist().
+                           Type :: field_type(),
+                           Acc :: list()) ->
+                                  iolist().
 decode_packed_values(<<>>, _, Acc) ->
     lists:reverse(Acc);
 decode_packed_values(Bytes, bool, Acc) ->
@@ -312,9 +312,9 @@ decode_packed_values(Bytes, Type, Acc) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec decode_value(Bytes :: binary(),
-		   WireType :: encoded_field_type(),
-		   ExpectedType :: field_type()) ->
-			  {any(),binary()}.
+                   WireType :: encoded_field_type(),
+                   ExpectedType :: field_type()) ->
+                          {any(),binary()}.
 decode_value(Bytes, ?TYPE_VARINT, ExpectedType) ->
     {Value, Rest} = decode_varint(Bytes),
     {typecast(Value, ExpectedType), Rest};
@@ -358,7 +358,7 @@ decode_value(Bytes,WireType,ExpectedType) ->
 
 %% @hidden
 -spec typecast(Value :: any(), Type :: field_type()) ->
-		      any().
+                      any().
 typecast(Value, SignedType) when SignedType =:= int32; SignedType =:= int64; SignedType =:= enum ->
     if
         Value band 16#8000000000000000 =/= 0 -> Value - 16#10000000000000000;
@@ -366,34 +366,34 @@ typecast(Value, SignedType) when SignedType =:= int32; SignedType =:= int64; Sig
     end;
 typecast(Value, SignedType) when SignedType =:= sint32; SignedType =:= sint64 ->
     (Value bsr 1) bxor (-(Value band 1));
-typecast(Value, Type) when Type =:= bool -> 
+typecast(Value, Type) when Type =:= bool ->
     Value =:= 1;
 typecast(Value, _) ->
     Value.
 
 %% @hidden
--spec encode_field_tag(FieldID :: non_neg_integer(), 
-		       FieldType :: encoded_field_type()) ->
-			      binary().
+-spec encode_field_tag(FieldID :: non_neg_integer(),
+                       FieldType :: encoded_field_type()) ->
+                              binary().
 encode_field_tag(FieldID, FieldType) when FieldID band 16#3fffffff =:= FieldID ->
     encode_varint((FieldID bsl 3) bor FieldType).
 
 %% @hidden
 -spec encode_varint_field(FieldID :: non_neg_integer(),
-			  Integer :: integer()) ->
-				 iolist().
+                          Integer :: integer()) ->
+                                 iolist().
 encode_varint_field(FieldID, Integer) ->
     [encode_field_tag(FieldID, ?TYPE_VARINT), encode_varint(Integer)].
 
 %% @hidden
 -spec encode_varint(I :: integer()) ->
-			   binary().
+                           binary().
 encode_varint(I) ->
     encode_varint(I, []).
 
 %% @hidden
 -spec encode_varint(I :: integer(), Acc :: list()) ->
-			   binary().
+                           binary().
 encode_varint(I, Acc) when I =< 16#7f ->
     iolist_to_binary(lists:reverse([I | Acc]));
 encode_varint(I, Acc) ->
@@ -404,15 +404,15 @@ encode_varint(I, Acc) ->
 
 %% @hidden
 -spec decode_varint(Bytes :: binary()) ->
-			   {integer(), binary()}.
+                           {integer(), binary()}.
 decode_varint(Bytes) ->
     decode_varint(Bytes, []).
 
--spec decode_varint(Bytes :: binary(), list()) -> 
-			   {integer(), binary()}.
+-spec decode_varint(Bytes :: binary(), list()) ->
+                           {integer(), binary()}.
 decode_varint(<<0:1, I:7, Rest/binary>>, Acc) ->
     Acc1 = [I|Acc],
-    Result = 
+    Result =
         lists:foldl(
             fun(X, Acc0) ->
                 (Acc0 bsl 7 bor X)

--- a/src/protobuffs_compile.erl
+++ b/src/protobuffs_compile.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2009 
+%% Copyright (c) 2009
 %% Nick Gerakines <nick@gerakines.net>
 %% Jacob Vorreuter <jacob.vorreuter@gmail.com>
 %%
@@ -27,8 +27,8 @@
 -ifdef(TEST).
 -compile(export_all).
 -else.
--export([scan_file/1, scan_file/2, scan_string/2, scan_string/3, 
-	 generate_source/1, generate_source/2]).
+-export([scan_file/1, scan_file/2, scan_string/2, scan_string/3,
+         generate_source/1, generate_source/2]).
 -endif.
 
 -record(collected,{enum=[], msg=[], extensions=[]}).
@@ -37,23 +37,23 @@
 %% @doc Generats a built .beam file and header file .hrl
 %%--------------------------------------------------------------------
 -spec scan_file(ProtoFile :: string()) ->
-		       ok | {error, _}.
+                       ok | {error, _}.
 scan_file(ProtoFile) ->
     scan_file(ProtoFile,[]).
 
 -spec scan_string(String :: string(), BaseName :: string()) ->
-			 ok | {error, _}.
+                         ok | {error, _}.
 scan_string(String,BaseName) ->
     scan_string(String,BaseName,[]).
 
 %%--------------------------------------------------------------------
 %% @doc Generats a built .beam file and header file .hrl
-%%      Considerd option properties: output_include_dir, 
+%%      Considerd option properties: output_include_dir,
 %%                                   output_ebin_dir,
 %%                                   imports_dir
 %%--------------------------------------------------------------------
 -spec scan_file(ProtoFile :: string() | atom(), Options :: list()) ->
-		       ok | {error, _}.
+                       ok | {error, _}.
 scan_file(ProtoFile,Options) when is_list(ProtoFile) ->
     Basename = filename:basename(ProtoFile, ".proto") ++ "_pb",
     {ok,String} = parse_file(ProtoFile),
@@ -64,20 +64,20 @@ scan_file(ProtoFile,Options) when is_atom(ProtoFile) ->
     scan_string(String,Basename,Options).
 
 -spec scan_string(String :: string(), Basename :: string(), Options :: list()) ->
-			 ok | {error, _}. 
+                         ok | {error, _}.
 scan_string(String,Basename,Options) ->
     {ok,FirstParsed} = parse_string(String),
     ImportPaths = ["./", "src/" | proplists:get_value(imports_dir, Options, [])],
     Parsed = parse_imports(FirstParsed, ImportPaths),
-    Collected = collect_full_messages(Parsed), 
+    Collected = collect_full_messages(Parsed),
     Messages = resolve_types(Collected#collected.msg,Collected#collected.enum),
     output(Basename, Messages, Collected#collected.enum, Options).
-    
+
 %%--------------------------------------------------------------------
 %% @doc Generats a source .erl file and header file .hrl
 %%--------------------------------------------------------------------
 -spec generate_source(ProtoFile :: string()) ->
-			     ok | {error, _}.
+                             ok | {error, _}.
 generate_source(ProtoFile) when is_atom(ProtoFile) ->
     generate_source(atom_to_list(ProtoFile),[]);
 generate_source(ProtoFile) ->
@@ -86,19 +86,19 @@ generate_source(ProtoFile) ->
 
 %%--------------------------------------------------------------------
 %% @doc Generats a source .erl file and header file .hrl
-%%      Consider option properties: output_include_dir, 
+%%      Consider option properties: output_include_dir,
 %%                                  output_src_dir,
 %%                                  imports_dir
 %%--------------------------------------------------------------------
 -spec generate_source(ProtoFile :: string(), Options :: list()) ->
-			     ok | {error, _}.
+                             ok | {error, _}.
 generate_source(ProtoFile,Options) when is_list (ProtoFile) ->
     Basename = ProtoFile ++ "_pb",
     {ok,String} = parse_file(ProtoFile),
     {ok,FirstParsed} = parse_string(String),
     ImportPaths = ["./", "src/" | proplists:get_value(imports_dir, Options, [])],
     Parsed = parse_imports(FirstParsed, ImportPaths),
-    Collected = collect_full_messages(Parsed), 
+    Collected = collect_full_messages(Parsed),
     Messages = resolve_types(Collected#collected.msg,Collected#collected.enum),
     output_source (Basename, Messages, Collected#collected.enum, Options).
 
@@ -111,20 +111,20 @@ parse_imports([], _Path, Acc) ->
     lists:reverse(Acc);
 parse_imports([{import, File} = Head | Tail], Path, Acc) ->
     case protobuffs_file:path_open(Path, File, [read]) of
-	{ok, F, Fullname} ->
-	    file:close(F),
-	    {ok,String} = parse_file(Fullname),
-	    {ok,FirstParsed} = parse_string(String),
-	    Parsed = lists:append(FirstParsed, Tail),
-	    parse_imports(Parsed, Path, [Head | Acc]);
-	{error, Error} ->
-	    error_logger:error_report([
-				       "Could not do import",
-				       {import, File},
-				       {error, Error},
-				       {path, Path}
-				      ]),
-	    parse_imports(Tail, Path, [Head | Acc])
+        {ok, F, Fullname} ->
+            file:close(F),
+            {ok,String} = parse_file(Fullname),
+            {ok,FirstParsed} = parse_string(String),
+            Parsed = lists:append(FirstParsed, Tail),
+            parse_imports(Parsed, Path, [Head | Acc]);
+        {error, Error} ->
+            error_logger:error_report([
+                                       "Could not do import",
+                                       {import, File},
+                                       {error, Error},
+                                       {path, Path}
+                                      ]),
+            parse_imports(Tail, Path, [Head | Acc])
     end;
 parse_imports([Head | Tail], Path, Acc) ->
     parse_imports(Tail, Path, [Head | Acc]).
@@ -132,10 +132,10 @@ parse_imports([Head | Tail], Path, Acc) ->
 %% @hidden
 output(Basename, Messages, Enums, Options) ->
     case proplists:get_value(output_include_dir,Options) of
-	undefined ->
-	    HeaderFile = Basename ++ ".hrl";
-	HeaderPath ->
-	    HeaderFile = filename:join(HeaderPath,Basename) ++ ".hrl"
+        undefined ->
+            HeaderFile = Basename ++ ".hrl";
+        HeaderPath ->
+            HeaderFile = filename:join(HeaderPath,Basename) ++ ".hrl"
     end,
 
     error_logger:info_msg("Writing header file to ~p~n",[HeaderFile]),
@@ -145,10 +145,10 @@ output(Basename, Messages, Enums, Options) ->
     Forms1 = filter_forms(Messages, Enums, Forms, Basename, []),
     {ok, _, Bytes, _Warnings} = protobuffs_file:compile_forms(Forms1, proplists:get_value(compile_flags,Options,[])),
     case proplists:get_value(output_ebin_dir,Options) of
-	undefined ->
-	    BeamFile = Basename ++ ".beam";
-	BeamPath ->
-	    BeamFile = filename:join(BeamPath,Basename) ++ ".beam"
+        undefined ->
+            BeamFile = Basename ++ ".beam";
+        BeamPath ->
+            BeamFile = filename:join(BeamPath,Basename) ++ ".beam"
     end,
     error_logger:info_msg("Writing beam file to ~p~n",[BeamFile]),
     protobuffs_file:write_file(BeamFile, Bytes).
@@ -156,10 +156,10 @@ output(Basename, Messages, Enums, Options) ->
 %% @hidden
 output_source (Basename, Messages, Enums, Options) ->
     case proplists:get_value(output_include_dir,Options) of
-	undefined ->
-	    HeaderFile = Basename ++ ".hrl";
-	HeaderPath ->
-	    HeaderFile = filename:join(HeaderPath,Basename) ++ ".hrl"
+        undefined ->
+            HeaderFile = Basename ++ ".hrl";
+        HeaderPath ->
+            HeaderFile = filename:join(HeaderPath,Basename) ++ ".hrl"
     end,
     error_logger:info_msg("Writing header file to ~p~n",[HeaderFile]),
     ok = write_header_include_file(HeaderFile, Messages),
@@ -167,10 +167,10 @@ output_source (Basename, Messages, Enums, Options) ->
     {ok,{_,[{abstract_code,{_,Forms}}]}} = beam_lib:chunks(PokemonBeamFile, [abstract_code]),
     Forms1 = filter_forms(Messages, Enums, Forms, Basename, []),
     case proplists:get_value(output_src_dir,Options) of
-	undefined ->
-	    SrcFile = Basename ++ ".erl";
-	SrcPath ->
-	    SrcFile = filename:join(SrcPath,Basename) ++ ".erl"
+        undefined ->
+            SrcFile = Basename ++ ".erl";
+        SrcPath ->
+            SrcFile = filename:join(SrcPath,Basename) ++ ".erl"
     end,
     error_logger:info_msg("Writing src file to ~p~n",[SrcFile]),
     protobuffs_file:write_file(SrcFile, erl_prettypr:format(erl_syntax:form_list (Forms1))).
@@ -188,7 +188,7 @@ parse_file(InFile,Acc) ->
         {ok,Token,_EndLine} ->
             parse_file(InFile,Acc ++ [Token]);
         {error,token} ->
-            exit(scanning_error);    
+            exit(scanning_error);
         {eof,_} ->
             Acc
     end.
@@ -205,28 +205,28 @@ filter_forms(Msgs, Enums, [{attribute,L,module,pokemon_pb}|Tail], Basename, Acc)
 
 filter_forms(Msgs, Enums, [{attribute,L,export,[{encode_pikachu,1},{decode_pikachu,1}]}|Tail], Basename, Acc) ->
     Exports = lists:foldl(
-		fun({Name,_,_}, Acc1) ->
-			[{list_to_atom("encode_" ++ string:to_lower(Name)),1},
-			 {list_to_atom("decode_" ++ string:to_lower(Name)),1} | Acc1]
-		end, [], Msgs),
+                fun({Name,_,_}, Acc1) ->
+                        [{list_to_atom("encode_" ++ string:to_lower(Name)),1},
+                         {list_to_atom("decode_" ++ string:to_lower(Name)),1} | Acc1]
+                end, [], Msgs),
     filter_forms(Msgs, Enums, Tail, Basename, [{attribute,L,export,Exports}|Acc]);
 
 filter_forms(Msgs, Enums, [{attribute,L,record,{pikachu,_}}|Tail], Basename, Acc) ->
     Records = [begin
-		   OutFields = [string:to_lower(A) || {_, _, _, A, _} <- lists:keysort(1, Fields)],
+                   OutFields = [string:to_lower(A) || {_, _, _, A, _} <- lists:keysort(1, Fields)],
        ExtendField = case Extends of
            disallowed -> [];
            _ -> [{record_field,L,{atom,L,'$extensions'}}]
        end,
-		   Frm_Fields = [{record_field,L,{atom,L,list_to_atom(OutField)}}|| OutField <- OutFields] ++ ExtendField,
-		   {attribute, L, record, {atomize(Name), Frm_Fields}}
-	       end || {Name, Fields,Extends} <- Msgs],
+                   Frm_Fields = [{record_field,L,{atom,L,list_to_atom(OutField)}}|| OutField <- OutFields] ++ ExtendField,
+                   {attribute, L, record, {atomize(Name), Frm_Fields}}
+               end || {Name, Fields,Extends} <- Msgs],
     filter_forms(Msgs, Enums, Tail, Basename, Records ++ Acc);
 
 filter_forms(Msgs, Enums, [{function,L,encode_pikachu,1,[Clause]}|Tail], Basename, Acc) ->
     Functions = [begin
-		     {function,L,list_to_atom("encode_" ++ string:to_lower(Name)),1,[replace_atom(Clause, pikachu, atomize(Name))]} 
-		 end || {Name, _, _} <- Msgs],
+                     {function,L,list_to_atom("encode_" ++ string:to_lower(Name)),1,[replace_atom(Clause, pikachu, atomize(Name))]}
+                 end || {Name, _, _} <- Msgs],
     filter_forms(Msgs, Enums, Tail, Basename, Functions ++ Acc);
 
 filter_forms(Msgs, Enums, [{function,L,encode,2,[Clause]}|Tail], Basename, Acc) ->
@@ -244,12 +244,12 @@ filter_forms(Msgs, Enums, [{function,L,encode_extensions,1,[EncodeClause,Catchal
 
 filter_forms(Msgs, Enums, [{function,L,decode_pikachu,1,[Clause]}|Tail], Basename, Acc) ->
     Functions = [begin
-		     {function,
-		      L,
-		      list_to_atom("decode_" ++ string:to_lower(Name)),
-		      1,
-		      [replace_atom(Clause, pikachu, atomize(Name))]} 
-		 end || {Name, _, _} <- Msgs],
+                     {function,
+                      L,
+                      list_to_atom("decode_" ++ string:to_lower(Name)),
+                      1,
+                      [replace_atom(Clause, pikachu, atomize(Name))]}
+                 end || {Name, _, _} <- Msgs],
     filter_forms(Msgs, Enums, Tail, Basename, Functions ++ Acc);
 
 filter_forms(Msgs, Enums, [{function,L,decode,2,[Clause]}|Tail], Basename, Acc) ->
@@ -310,7 +310,7 @@ filter_set_extension([{MsgName,_,Extends}|Tail],Clause,Acc) ->
     {match,L2,NewReturn,OldDictStore} = OldSet,
     {call,L2,DictStore,[_StoreKey,_StoreVal,StoreVar]} = OldDictStore,
     {tuple,L3,[Ok, OldReturnRec]} = OldReturn,
-    {record,L3,ReturnRecVar,OldName,Fields} = OldReturnRec,
+    {record,L3,ReturnRecVar,_OldName,Fields} = OldReturnRec,
     Folder = fun({Id, Rule, StrType, Name, Opts}, Facc) ->
         Type = atomize(StrType),
         FClause = {clause,L,[{match,L,{record,L,atomize(MsgName),RecArgFields},RecVar},{atom,L,atomize(Name)},ValueArg],Gs,[
@@ -339,13 +339,13 @@ filter_get_extension_atom([{Msg,_,Extends}|Tail],Clause,Acc) ->
       {FId, _, _, FName, _} <- Extends],
     NewAcc = lists:append(NewClauses,Acc),
     filter_get_extension_atom(Tail,Clause,NewAcc).
- 
+
 %% @hidden
 filter_get_extension_integer([],_,Acc) ->
     Acc;
 filter_get_extension_integer([{_,_,disallowed}|Tail],IntClause,Acc) ->
     filter_get_extension_integer(Tail,IntClause,Acc);
-filter_get_extension_integer([{Msg,_,Extends}|Tail],IntClause,Acc) ->
+filter_get_extension_integer([{Msg,_,_Extends}|Tail],IntClause,Acc) ->
     {clause,L,[{record,L,Pikachu,Fields},IntArg],Gs,Body} = IntClause,
     NewRecName = replace_atom(Pikachu, pikachu, atomize(Msg)),
     NewRecArg = {record,L,NewRecName,Fields},
@@ -357,13 +357,13 @@ filter_get_extension_integer([{Msg,_,Extends}|Tail],IntClause,Acc) ->
 filter_has_extension([], _, Acc) ->
     % non-reverseal is intentional.
     Acc;
-filter_has_extension([{Msg,_,disallowed}|Tail], Clause, Acc) ->
+filter_has_extension([{_Msg,_,disallowed}|Tail], Clause, Acc) ->
     filter_has_extension(Tail, Clause, Acc);
 filter_has_extension([{MsgName,_,Extends}|Tail], Clause, Acc) ->
     {clause,L,[OldRecArg,_],G,[Body]} = Clause,
-		{call, L1, {remote,L1,Dict,IsKey},[_Key,DictArg]} = Body,
+                {call, L1, {remote,L1,Dict,IsKey},[_Key,DictArg]} = Body,
     RecArg = replace_atom(OldRecArg,pikachu,atomize(MsgName)),
-    Folder = fun({ID, Rules, Type, Name, Other}, FoldAcc) ->
+    Folder = fun({ID, _Rules, _Type, Name, _Other}, FoldAcc) ->
         AtomClause = {clause,L,[RecArg,{atom,L,atomize(Name)}],G,[
             {call,L,{remote,L,Dict,IsKey},[{atom,L,atomize(Name)},DictArg]}
         ]},
@@ -375,12 +375,12 @@ filter_has_extension([{MsgName,_,Extends}|Tail], Clause, Acc) ->
     NewClauses = lists:foldl(Folder, [], Extends),
     NewAcc = lists:append(Acc,NewClauses),
     filter_has_extension(Tail,Clause,NewAcc).
-    
+
 %% @hidden
 filter_extension_size([], _RecClause, Acc) ->
     % the non-reversal is intentional.
     Acc;
-filter_extension_size([{MsgName,_,disallowed}|Tail],Clause,Acc) ->
+filter_extension_size([{_MsgName,_,disallowed}|Tail],Clause,Acc) ->
     filter_extension_size(Tail,Clause,Acc);
 filter_extension_size([{MsgName,_,_}|Tail],Clause,Acc) ->
     {clause,L,[OldArg],G,Body} = Clause,
@@ -389,7 +389,7 @@ filter_extension_size([{MsgName,_,_}|Tail],Clause,Acc) ->
     filter_extension_size(Tail,Clause,NewAcc).
 
 %% @hidden
-filter_encode_clause({MsgName, _Fields,_Extends}, {clause,L,_Args,Guards,Content}) ->
+filter_encode_clause({MsgName, _Fields,_Extends}, {clause,L,_Args,Guards,_Content}) ->
     ToBin = {call,L,{atom,L,iolist_to_binary},[
         {op,L,'++',
             {call,L, {atom,L,iolist}, [{atom,L,atomize(MsgName)},{var,L,'Record'}]},
@@ -411,37 +411,37 @@ filter_iolist_clause({MsgName, Fields0, _Extends0}, {clause,L,_Args,Guards,_Cont
         end
         || {FNum,Tag,SType,SName,_} = Field <- Fields0 ],
     Cons = lists:foldl(
-	     fun({FNum,Tag,SType,SName,Default}, Acc) ->
-		     {cons,L,
-		      {call,L,{atom,L,pack},[{integer,L,FNum},
-					     {atom,L,Tag},
-					     {call,L,
-					      {atom,L,with_default},
-					      [{record_field,L,
-						{var,L,'Record'},atomize(MsgName),
-						{atom,L,atomize(SName)}},
-					       erl_parse:abstract(Default)]},
-					     {atom,L,atomize(SType)},
-					     {nil,L}]},
-		      Acc}
-	     end, {nil,L}, Fields),
+             fun({FNum,Tag,SType,SName,Default}, Acc) ->
+                     {cons,L,
+                      {call,L,{atom,L,pack},[{integer,L,FNum},
+                                             {atom,L,Tag},
+                                             {call,L,
+                                              {atom,L,with_default},
+                                              [{record_field,L,
+                                                {var,L,'Record'},atomize(MsgName),
+                                                {atom,L,atomize(SName)}},
+                                               erl_parse:abstract(Default)]},
+                                             {atom,L,atomize(SType)},
+                                             {nil,L}]},
+                      Acc}
+             end, {nil,L}, Fields),
     {clause,L,[{atom,L,atomize(MsgName)},{var,L,'Record'}],Guards,[Cons]}.
 
 %% @hidden
 expand_decode_function(Msgs, Line, Clause) ->
-    {function,Line,decode,2, [{clause,Line,[{atom,Line,enummsg_values},{integer,Line,1}],[],[{atom,Line,value1}]}] ++ 
+    {function,Line,decode,2, [{clause,Line,[{atom,Line,enummsg_values},{integer,Line,1}],[],[{atom,Line,value1}]}] ++
      [filter_decode_clause(Msgs, Msg, Clause) || Msg <- Msgs]}.
 
 %% @hidden
 filter_decode_clause(Msgs, {MsgName, Fields, Extends}, {clause,L,_Args,Guards,[_,_,C,D]}) ->
-    Types = lists:keysort(1, [{FNum, list_to_atom(SName), 
-			       atomize(SType), 
-			       decode_opts(Msgs, Tag, SType), Def} ||
-				 {FNum,Tag,SType,SName,Def} <- Fields]),
+    Types = lists:keysort(1, [{FNum, list_to_atom(SName),
+                               atomize(SType),
+                               decode_opts(Msgs, Tag, SType), Def} ||
+                                 {FNum,Tag,SType,SName,Def} <- Fields]),
     Cons = lists:foldl(
-	     fun({FNum, FName, Type, Opts, _Def}, Acc) ->
-		     {cons,L,{tuple,L,[{integer,L,FNum},{atom,L,FName},{atom,L,Type},erl_parse:abstract(Opts)]},Acc}
-	     end, {nil,L}, Types),
+             fun({FNum, FName, Type, Opts, _Def}, Acc) ->
+                     {cons,L,{tuple,L,[{integer,L,FNum},{atom,L,FName},{atom,L,Type},erl_parse:abstract(Opts)]},Acc}
+             end, {nil,L}, Types),
     ExtendDefault = case Extends of
         disallowed -> {nil,L};
         _ -> erl_parse:abstract([{false, '$extensions', dict:new()}])
@@ -467,14 +467,14 @@ filter_decode_extensions_clause(Msgs,[{_,_,disallowed}|Tail],Clause,Acc) ->
     filter_decode_extensions_clause(Msgs,Tail,Clause,Acc);
 filter_decode_extensions_clause(Msgs,[{MsgName,_,Extends}|Tail],Clause,Acc) ->
     {clause,L,_,_,_} = Clause,
-    Types = lists:keysort(1, [{FNum, list_to_atom(SName), 
-			       atomize(SType), 
-			       decode_opts(Msgs, Tag, SType), Def} ||
-				 {FNum,Tag,SType,SName,Def} <- Extends]),
+    Types = lists:keysort(1, [{FNum, list_to_atom(SName),
+                               atomize(SType),
+                               decode_opts(Msgs, Tag, SType), Def} ||
+                                 {FNum,Tag,SType,SName,Def} <- Extends]),
     Cons = lists:foldl(
-	     fun({FNum, FName, Type, Opts, _Def}, Acc) ->
-		     {cons,L,{tuple,L,[{integer,L,FNum},{atom,L,FName},{atom,L,Type},erl_parse:abstract(Opts)]},Acc}
-	     end, {nil,L}, Types),
+             fun({FNum, FName, Type, Opts, _Def}, InnerAcc) ->
+                     {cons,L,{tuple,L,[{integer,L,FNum},{atom,L,FName},{atom,L,Type},erl_parse:abstract(Opts)]},InnerAcc}
+             end, {nil,L}, Types),
 %    Defaults = lists:foldr(
 %        fun
 %            ({_FNum, _FName, _Type, _Opts, none}, Acc) ->
@@ -487,9 +487,9 @@ filter_decode_extensions_clause(Msgs,[{MsgName,_,Extends}|Tail],Clause,Acc) ->
     A = {match,L,{var,L,'Types'},Cons},
     %B = {match,L,{var,L,'Defaults'},Defaults},
     %D1 = replace_atom(D, pikachu, atomize(MsgName)),
-		{clause,L,[Arg],Guards,[_,B,C]} = Clause,
-		NewBody = [A,B,replace_atom(C,pikachu,atomize(MsgName))],
-		NewClause = {clause,L,[replace_atom(Arg, pikachu, atomize(MsgName))],Guards,NewBody},
+                {clause,L,[Arg],Guards,[_,B,C]} = Clause,
+                NewBody = [A,B,replace_atom(C,pikachu,atomize(MsgName))],
+                NewClause = {clause,L,[replace_atom(Arg, pikachu, atomize(MsgName))],Guards,NewBody},
     filter_decode_extensions_clause(Msgs,Tail,Clause,[NewClause|Acc]).
 
 %% @hidden
@@ -511,14 +511,14 @@ expand_to_record_function(Msgs, Line, Clause) ->
     {function,Line,to_record,2,[filter_to_record_clause(Msg, Clause) || Msg <- Msgs]}.
 
 %% @hidden
-filter_to_record_clause({MsgName, _, Extends}, {clause,L,[_Param1,Param2],Guards,[Fold,DecodeExtends]}) ->
+filter_to_record_clause({MsgName, _, Extends}, {clause,L,[_Param1,Param2],Guards,[Fold,_DecodeExtends]}) ->
     Fold1 = replace_atom(Fold, pikachu, atomize(MsgName)),
     ReturnLine = case Extends of
         disallowed ->
             {var,L,'Record1'};
         _ ->
             {ok, Tokens, _} = erl_scan:string("decode_extensions(Record1)."),
-	          {ok, [Abstract]} = erl_parse:parse_exprs(Tokens),
+                  {ok, [Abstract]} = erl_parse:parse_exprs(Tokens),
             Abstract
     end,
     {clause,L,[{atom,L,atomize(MsgName)},Param2],Guards,[Fold1,ReturnLine]}.
@@ -556,29 +556,29 @@ filter_int_to_enum_clause({enum,EnumTypeName,IntValue,EnumValue}, {clause,L,_Arg
 collect_full_messages(Data) -> collect_full_messages(Data, #collected{}).
 collect_full_messages([{message, Name, Fields} | Tail], Collected) ->
     ListName = case erlang:is_list (hd(Name)) of
-		   true -> Name;
-		   false -> [Name]
-	       end,
-    
+                   true -> Name;
+                   false -> [Name]
+               end,
+
     FieldsOut = lists:foldl(
-		  fun ({_,_,_,_,_} = Input, TmpAcc) -> [Input | TmpAcc];
-		      (_, TmpAcc) -> TmpAcc
-		  end, [], Fields),
-    
+                  fun ({_,_,_,_,_} = Input, TmpAcc) -> [Input | TmpAcc];
+                      (_, TmpAcc) -> TmpAcc
+                  end, [], Fields),
+
     Enums = lists:foldl(
-	      fun ({enum,C,D}, TmpAcc) -> [{enum, [C | ListName], D} | TmpAcc];
-		  (_, TmpAcc) -> TmpAcc
-	      end, [], Fields),
-    
+              fun ({enum,C,D}, TmpAcc) -> [{enum, [C | ListName], D} | TmpAcc];
+                  (_, TmpAcc) -> TmpAcc
+              end, [], Fields),
+
     Extensions = lists:foldl(
-		   fun ({extensions, From, To}, TmpAcc) -> [{From,To}|TmpAcc];
-		       (_, TmpAcc) -> TmpAcc
-		   end, [], Fields),
-			   
+                   fun ({extensions, From, To}, TmpAcc) -> [{From,To}|TmpAcc];
+                       (_, TmpAcc) -> TmpAcc
+                   end, [], Fields),
+
     SubMessages = lists:foldl(
-		    fun ({message, C, D}, TmpAcc) -> [{message, [C | ListName], D} | TmpAcc];
-			(_, TmpAcc) -> TmpAcc
-		    end, [], Fields),
+                    fun ({message, C, D}, TmpAcc) -> [{message, [C | ListName], D} | TmpAcc];
+                        (_, TmpAcc) -> TmpAcc
+                    end, [], Fields),
 
     ExtendedFields = case Extensions of
         [] -> disallowed;
@@ -586,27 +586,27 @@ collect_full_messages([{message, Name, Fields} | Tail], Collected) ->
     end,
 
     NewCollected = Collected#collected{
-		     msg=[{ListName, FieldsOut, ExtendedFields} | Collected#collected.msg],
-		     extensions=[{ListName,Extensions} | Collected#collected.extensions]
-		    },
+                     msg=[{ListName, FieldsOut, ExtendedFields} | Collected#collected.msg],
+                     extensions=[{ListName,Extensions} | Collected#collected.extensions]
+                    },
     collect_full_messages(Tail ++ SubMessages ++ Enums, NewCollected);
 collect_full_messages([{enum, Name, Fields} | Tail], Collected) ->
     ListName = case erlang:is_list (hd(Name)) of
-		   true -> Name;
-		   false -> [Name]
-	       end,
+                   true -> Name;
+                   false -> [Name]
+               end,
 
     FieldsOut = lists:foldl(
-		  fun (Field, TmpAcc) ->
-			  case Field of
-			      {EnumAtom, IntValue} -> [{enum, 
-							type_path_to_type(ListName), 
-							IntValue, 
-							EnumAtom} | TmpAcc];
-			      _ -> TmpAcc
-			  end
-		  end, [], Fields),
-    
+                  fun (Field, TmpAcc) ->
+                          case Field of
+                              {EnumAtom, IntValue} -> [{enum,
+                                                        type_path_to_type(ListName),
+                                                        IntValue,
+                                                        EnumAtom} | TmpAcc];
+                              _ -> TmpAcc
+                          end
+                  end, [], Fields),
+
     NewCollected = Collected#collected{enum=FieldsOut++Collected#collected.enum},
     collect_full_messages(Tail, NewCollected);
 collect_full_messages([{package, _PackageName} | Tail], Collected) ->
@@ -617,40 +617,40 @@ collect_full_messages([{import, _Filename} | Tail], Collected) ->
     collect_full_messages(Tail, Collected);
 collect_full_messages([{extend, Name, ExtendedFields} | Tail], Collected) ->
     ListName = case erlang:is_list (hd(Name)) of
-		   true -> Name;
-		   false -> [Name]
-	       end,
+                   true -> Name;
+                   false -> [Name]
+               end,
 
     CollectedMsg = Collected#collected.msg,
     {ListName,FieldsOut,ExtendFields} = lists:keyfind(ListName,1,CollectedMsg),
     {ListName,Extensions} = lists:keyfind(ListName,1,Collected#collected.extensions),
-    
+
     FunNotInReservedRange = fun(Id) -> not(19000 =< Id andalso Id =< 19999) end,
     FunInRange = fun(Id,From,max) -> From =< Id andalso Id =< 16#1fffffff;
-		    (Id,From,To) -> From =< Id andalso Id =< To
-		 end,
-    
+                    (Id,From,To) -> From =< Id andalso Id =< To
+                 end,
+
     ExtendedFieldsOut = lists:append(FieldsOut,
-			     lists:foldl(
-			       fun ({Id, _, _, FieldName, _} = Input, TmpAcc) ->
-				       case lists:any(fun({From,To}) -> FunNotInReservedRange(Id) 
-									    andalso FunInRange(Id,From,To)
-						      end,Extensions) of 
-					   true ->
-					       [Input | TmpAcc];
-					   _ ->
-					       error_logger:error_report(["Extended field not in valid range",
-									  {message, Name},
-									  {field_id,Id},
-									  {field_name,FieldName},
-									  {defined_ranges,Extensions},
-									  {reserved_range,{19000,19999}},
-									  {max,16#1fffffff}]),
-					       throw(out_of_range)
-				       end;
-				   (_, TmpAcc) -> TmpAcc
-			       end, [], ExtendedFields)
-			     ),
+                             lists:foldl(
+                               fun ({Id, _, _, FieldName, _} = Input, TmpAcc) ->
+                                       case lists:any(fun({From,To}) -> FunNotInReservedRange(Id)
+                                                                            andalso FunInRange(Id,From,To)
+                                                      end,Extensions) of
+                                           true ->
+                                               [Input | TmpAcc];
+                                           _ ->
+                                               error_logger:error_report(["Extended field not in valid range",
+                                                                          {message, Name},
+                                                                          {field_id,Id},
+                                                                          {field_name,FieldName},
+                                                                          {defined_ranges,Extensions},
+                                                                          {reserved_range,{19000,19999}},
+                                                                          {max,16#1fffffff}]),
+                                               throw(out_of_range)
+                                       end;
+                                   (_, TmpAcc) -> TmpAcc
+                               end, [], ExtendedFields)
+                             ),
     NewExtends = case ExtendFields of
         disallowed -> disallowed;
         _ -> ExtendFields ++ ExtendedFieldsOut
@@ -660,7 +660,7 @@ collect_full_messages([{extend, Name, ExtendedFields} | Tail], Collected) ->
 %% Skip anything we don't understand
 collect_full_messages([Skip|Tail], Acc) ->
     error_logger:warning_report(["Unkown, skipping",
-				 {skip,Skip}]), 
+                                 {skip,Skip}]),
     collect_full_messages(Tail, Acc);
 collect_full_messages([], Collected) ->
     Collected.
@@ -669,37 +669,37 @@ collect_full_messages([], Collected) ->
 resolve_types (Data, Enums) -> resolve_types (Data, Data, Enums, []).
 resolve_types ([{TypePath, Fields,Extended} | Tail], AllPaths, Enums, Acc) ->
     FolderFun = fun (Input, TmpAcc) ->
-			  case Input of
-			      {Index, Rules, Type, Identifier, Other} ->
-				  case is_scalar_type (Type) of
-				      true -> [Input | TmpAcc];
-				      false ->
-					  PossiblePaths =
-					      case string:tokens (Type,".") of
-						  [Type] ->
-						      all_possible_type_paths (Type, TypePath);
-						  FullPath ->
-						% handle types of the form Foo.Bar which are absolute,
-						% so we just convert to a type path and check it.
-						      [lists:reverse (FullPath)]
-					      end,
-					  RealPath =
-					      case find_type (PossiblePaths, AllPaths) of
-						  false ->
-						      case is_enum_type(Type, PossiblePaths, Enums) of
-							  {true,EnumType} ->
-							      EnumType;
-							  false ->
-							      throw (["Unknown Type ", Type])
-						      end;
-						  ResultType ->
-						      ResultType
-					      end,
-					  [{Index, Rules, type_path_to_type (RealPath), Identifier, Other} | TmpAcc]
-				  end;
-			      _ -> TmpAcc
-			  end
-		end,
+                          case Input of
+                              {Index, Rules, Type, Identifier, Other} ->
+                                  case is_scalar_type (Type) of
+                                      true -> [Input | TmpAcc];
+                                      false ->
+                                          PossiblePaths =
+                                              case string:tokens (Type,".") of
+                                                  [Type] ->
+                                                      all_possible_type_paths (Type, TypePath);
+                                                  FullPath ->
+                                                % handle types of the form Foo.Bar which are absolute,
+                                                % so we just convert to a type path and check it.
+                                                      [lists:reverse (FullPath)]
+                                              end,
+                                          RealPath =
+                                              case find_type (PossiblePaths, AllPaths) of
+                                                  false ->
+                                                      case is_enum_type(Type, PossiblePaths, Enums) of
+                                                          {true,EnumType} ->
+                                                              EnumType;
+                                                          false ->
+                                                              throw (["Unknown Type ", Type])
+                                                      end;
+                                                  ResultType ->
+                                                      ResultType
+                                              end,
+                                          [{Index, Rules, type_path_to_type (RealPath), Identifier, Other} | TmpAcc]
+                                  end;
+                              _ -> TmpAcc
+                          end
+                end,
     FieldsOut = lists:foldl(FolderFun, [], Fields),
     ExtendedOut = case Extended of
         disallowed ->
@@ -791,16 +791,16 @@ is_enum_type(_Type, [], _Enums) ->
 is_enum_type(Type, [TypePath|Paths], Enums) ->
     case is_enum_type(type_path_to_type(TypePath), Enums) of
       true ->
-	{true,TypePath};
+        {true,TypePath};
       false ->
-	is_enum_type(Type, Paths, Enums)
+        is_enum_type(Type, Paths, Enums)
     end.
 is_enum_type(Type, Enums) ->
     case lists:keysearch(Type,2,Enums) of
-	false ->
-	    false;
-	{value,_} ->
-	    true
+        false ->
+            false;
+        {value,_} ->
+            true
     end.
 
 %% @hidden
@@ -814,10 +814,10 @@ sublists(List,Acc) ->
 %% @hidden
 all_possible_type_paths (Type, TypePath) ->
     lists:foldl (fun (TypeSuffix, AccIn) ->
-			 [[Type | TypeSuffix] | AccIn]
-		 end,
-		 [],
-		 sublists (TypePath)).
+                         [[Type | TypeSuffix] | AccIn]
+                 end,
+                 [],
+                 sublists (TypePath)).
 
 %% @hidden
 find_type ([], _KnownTypes) ->

--- a/src/protobuffs_file.erl
+++ b/src/protobuffs_file.erl
@@ -9,23 +9,34 @@
 
 -export([open/2,path_open/3,close/1,format/3,request/1,compile_forms/2,write_file/2]).
 
+-spec open(file:name(), file:mode()) ->
+                  {ok, file:io_device()} |
+                  {error, file:posix() | badarg | system_limit}.
 open(File, Options) ->
     file:open(File,Options).
 
+-spec path_open(file:name(), file:name(), file:mode()) ->
+                       {ok, file:io_device(), file:filename()} |
+                       {error, file:posix() | badarg | system_limit}.
 path_open(Path, File, Modes) ->
     file:path_open(Path, File, Modes).
 
+-spec close(file:io_device()) -> ok | {error, file:posix() | badarg | terminated}.
 close(FileRef) ->
     file:close(FileRef).
 
+-spec format(file:io_device(), io:format(), term()) -> ok.
 format(FileRef, FormatString, WriteFields) ->
     io:format(FileRef, FormatString, WriteFields).
 
+-spec request(file:io_device()) -> any.
 request(InFile) ->
     io:request(InFile,{get_until,prompt,protobuffs_scanner,token,[1]}).
 
+-spec compile_forms(any(), any()) -> any().
 compile_forms(Forms, Options) ->
     compile:forms(Forms, [return] ++ Options).
 
+-spec write_file(file:name(), iodata()) -> ok | {error | file:posix() | badarg | terminated | system_limit}.
 write_file(File, Bytes) ->
     file:write_file(File,Bytes).

--- a/src/protobuffs_parser.yrl
+++ b/src/protobuffs_parser.yrl
@@ -6,48 +6,48 @@ Terminals ';' '=' '{' '}' '[' ']' '(' ')' string integer float var.
 Rootsymbol g_protobuffs.
 Endsymbol '$end'.
 
-g_protobuffs -> '$empty'					: [].
-g_protobuffs -> g_header g_protobuffs				: ['$1'|'$2'].
-g_protobuffs -> g_message g_protobuffs 				: ['$1'|'$2'].
+g_protobuffs -> '$empty'                                        : [].
+g_protobuffs -> g_header g_protobuffs                           : ['$1'|'$2'].
+g_protobuffs -> g_message g_protobuffs                          : ['$1'|'$2'].
 
-g_header -> g_var string ';'					: {'$1', unwrap('$2')}.
-g_header -> g_var g_var ';'					: {'$1', safe_string('$2')}.
-g_header -> g_var g_var '=' g_value ';'				: {'$1', '$2', '$4'}.
+g_header -> g_var string ';'                                    : {'$1', unwrap('$2')}.
+g_header -> g_var g_var ';'                                     : {'$1', safe_string('$2')}.
+g_header -> g_var g_var '=' g_value ';'                         : {'$1', '$2', '$4'}.
 
-g_message -> g_var g_var '{' g_elements '}'			: {'$1', safe_string('$2'), '$4'}.
-g_message -> g_var g_var '{' g_rpcs '}'				: {'$1', safe_string('$2'), '$4'}.
-g_message -> g_var g_var '{' '}'					: {'$1', safe_string('$2'), []}.
+g_message -> g_var g_var '{' g_elements '}'                     : {'$1', safe_string('$2'), '$4'}.
+g_message -> g_var g_var '{' g_rpcs '}'                         : {'$1', safe_string('$2'), '$4'}.
+g_message -> g_var g_var '{' '}'                                        : {'$1', safe_string('$2'), []}.
 
-g_rpcs -> g_rpc							: ['$1'].
-g_rpcs -> g_rpc g_rpcs						: ['$1' | '$2'].
+g_rpcs -> g_rpc                                                 : ['$1'].
+g_rpcs -> g_rpc g_rpcs                                          : ['$1' | '$2'].
 
-g_rpc -> g_var g_var '(' g_var ')' g_var '(' g_var ')' ';'	: {'$1', safe_string('$2'), safe_string('$4'), safe_string('$8')}.
+g_rpc -> g_var g_var '(' g_var ')' g_var '(' g_var ')' ';'      : {'$1', safe_string('$2'), safe_string('$4'), safe_string('$8')}.
 
-g_elements -> g_element						: ['$1'].
-g_elements -> g_element g_elements				: ['$1' | '$2'].
+g_elements -> g_element                                         : ['$1'].
+g_elements -> g_element g_elements                              : ['$1' | '$2'].
 
-g_element -> g_var g_var g_var '=' integer g_default ';'	: {unwrap('$5'), pack_repeated('$1','$6'), safe_string('$2'), safe_string('$3'), default('$1','$6')}.
-g_element -> g_var '=' integer ';'				: {'$1', unwrap('$3')}.
-g_element -> g_var integer g_var integer ';' 			: {'$1', unwrap('$2'), unwrap('$4')}.
-g_element -> g_var integer g_var g_var ';' 			: {'$1', unwrap('$2'), '$4'}.
-g_element -> g_var g_var '=' g_value ';'			: {'$1', '$2', '$4'}.
-g_element -> g_message						: '$1'.
+g_element -> g_var g_var g_var '=' integer g_default ';'        : {unwrap('$5'), pack_repeated('$1','$6'), safe_string('$2'), safe_string('$3'), default('$1','$6')}.
+g_element -> g_var '=' integer ';'                              : {'$1', unwrap('$3')}.
+g_element -> g_var integer g_var integer ';'                    : {'$1', unwrap('$2'), unwrap('$4')}.
+g_element -> g_var integer g_var g_var ';'                      : {'$1', unwrap('$2'), '$4'}.
+g_element -> g_var g_var '=' g_value ';'                        : {'$1', '$2', '$4'}.
+g_element -> g_message                                          : '$1'.
 
-g_var -> var 							: unwrap('$1').
+g_var -> var                                                    : unwrap('$1').
 
-g_value -> g_var						: '$1'.
-g_value -> integer						: unwrap('$1').
-g_value -> string						: unwrap('$1').
-g_value -> float						: unwrap('$1').
+g_value -> g_var                                                : '$1'.
+g_value -> integer                                              : unwrap('$1').
+g_value -> string                                               : unwrap('$1').
+g_value -> float                                                : unwrap('$1').
 
 g_default -> '$empty' : none.
-g_default -> '[' g_var '=' g_value ']' 				: {'$2', '$4'}.
+g_default -> '[' g_var '=' g_value ']'                          : {'$2', '$4'}.
 
 Erlang code.
 safe_string(A) -> make_safe(atom_to_list(A)).
 
 make_safe(String) ->
-  case erl_scan:reserved_word(list_to_atom(String)) of 
+  case erl_scan:reserved_word(list_to_atom(String)) of
     true -> "pb_"++String;
     false -> String
   end.


### PR DESCRIPTION
This PR cleans up compiler warnings and gets rid of extra whitespace. Note, there are still some compiler warnings from parsetool. Please let me know if the -specs look OK.
