### PR TITLE
Fix round-tripping problem for 'bytes' fields.

### DIFF
--- a/src/protobuffs.erl
+++ b/src/protobuffs.erl
@@ -141,7 +141,7 @@ encode_internal(FieldID, String, string) when is_list(String) ->
 encode_internal(FieldID, String, string) when is_binary(String) ->
     encode_internal(FieldID, String, bytes);
 encode_internal(FieldID, String, bytes) when is_list(String) ->
-    encode_internal(FieldID, unicode:characters_to_binary(String), bytes);
+    encode_internal(FieldID, list_to_binary(String), bytes);
 encode_internal(FieldID, Bytes, bytes) when is_binary(Bytes) ->
     [encode_field_tag(FieldID, ?TYPE_STRING), encode_varint(size(Bytes)), Bytes];
 encode_internal(FieldID, Float, float) when is_integer(Float) ->


### PR DESCRIPTION
According to Google's spec([1](https://developers.google.com/protocol-buffers/docs/proto)), `bytes` fields can be arbitrary octet-sequences, whereas `string` fields must be encoded as UTF-8 or 7-bit ASCII (with top-bit of each byte 0, obviously).

It follows that in Erlang, list values assigned to `bytes` fields should be assumed to be byte-sequences and encoded using `erlang:list_to_binary/1`. This means that a list containing integers outside `0..127` will (by-design) result in a `badarg` exception.

We can still assume that lists assigned to `string` fields must be UTF-8 or ASCII, so `unicode:characters_to_binary/1` is appropriate there.

The decoding logic remains unchanged because it behaves as specified.
