### PR TITLE
Fix crash when a syntax identifier is provided

### DIFF
--- a/src/protobuffs_compile.erl
+++ b/src/protobuffs_compile.erl
@@ -629,6 +629,8 @@ collect_full_messages([{enum, Name, Fields} | Tail], Collected) ->
 
     NewCollected = Collected#collected{enum=FieldsOut++Collected#collected.enum},
     collect_full_messages(Tail, NewCollected);
+collect_full_messages([{syntax,_} | Tail], Collected) ->
+    collect_full_messages(Tail, Collected);
 collect_full_messages([{package, PackageName} | Tail], Collected) ->
     collect_full_messages(Tail, Collected#collected{package = PackageName});
 collect_full_messages([{option,_,_} | Tail], Collected) ->

--- a/src/protobuffs_parser.yrl
+++ b/src/protobuffs_parser.yrl
@@ -13,6 +13,7 @@ g_protobuffs -> g_message g_protobuffs 				: ['$1'|'$2'].
 g_header -> g_var string ';'					: {'$1', unwrap('$2')}.
 g_header -> g_var g_var ';'					: {'$1', safe_string('$2')}.
 g_header -> g_var g_var '=' g_value ';'				: {'$1', '$2', '$4'}.
+g_header -> g_var '=' g_value ';'					: {'$1', '$3'}.
 
 g_message -> g_var g_var '{' g_elements '}'			: {'$1', safe_string('$2'), '$4'}.
 g_message -> g_var g_var '{' g_rpcs '}'				: {'$1', safe_string('$2'), '$4'}.


### PR DESCRIPTION
Example: https://developers.google.com/transit/gtfs-realtime/gtfs-realtime-proto
