### PR TITLE
Fix import path argument

### DIFF
--- a/src/protobuffs_compile.erl
+++ b/src/protobuffs_compile.erl
@@ -95,7 +95,7 @@ generate_source(ProtoFile,Options) when is_list(ProtoFile) ->
     Basename = filename:basename(ProtoFile, ".proto") ++ "_pb",
     {ok,String} = parse_file(ProtoFile),
     {ok,FirstParsed} = parse_string(String),
-    ImportPaths = ["./", "src/" | proplists:get_value(imports_dir, Options, [])],
+    ImportPaths = ["./", "src/" | [proplists:get_value(imports_dir, Options, [])]],
     Parsed = parse_imports(FirstParsed, ImportPaths),
     Collected = collect_full_messages(Parsed),
     Messages = resolve_types(Collected#collected.msg,Collected#collected.enum),


### PR DESCRIPTION
If an `imports_dir` argument is specified to `protobuffs_compile:generate_source/2`,
the pathname was being added as individual characters.  (The string is being appended to the list as a list of characters).  Wrap the argument in brackets to insert as a string.

``` erlang
protobuffs_compile:generate_source("myfile.proto", [{imports_dir, "proto/"}]).
% gave
ImportPath == [ "./", "src/", 112, 114, 111, 116, 111, 47 ]
% after this change: 
ImportPath == [ "./", "src/", "proto/" ]
```
