### PR TITLE
Fix enums when using packages

### DIFF
--- a/src/protobuffs_compile.erl
+++ b/src/protobuffs_compile.erl
@@ -800,9 +800,11 @@ generate_field_definitions([{Name, _, Default} | Tail], Acc) ->
     generate_field_definitions(Tail, [Head | Acc]).
 
 %% @hidden
-atomize([String]) ->
+% handle ["symbol"]
+atomize([String]) when is_list(String) ->
     atomize(String);
-atomize([String|[_Rest]]) ->
+% handle ["symbol", "package_symbol"]
+atomize([String|[_Rest]]) when is_list(String) ->
     atomize(String);
 atomize(String) ->
     list_to_atom(string:to_lower(String)).


### PR DESCRIPTION
_Fix for https://github.com/basho/erlang_protobuffs/issues/43_

Use of a package name and enums was breaking compilation.
`protobuffs_compile:atomize/1` is passed three variants of arguments
when using enums and packages:

``` erlang
  "myenum"
  [ "myenum" ]
  [ "myenum", "my.package_myenum" ]
```

Add additional function clauses for `atomize` to handle the variants.
