### PR TITLE
Switching from ./bin/protoc-erl to self contained escript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 REBAR=`which rebar || printf ./rebar`
 REPO=protobuffs
-all: get-deps compile
+all: get-deps compile build
 
 get-deps:
 	@$(REBAR) get-deps
 
 compile:
 	@$(REBAR) compile
+
+build: compile
+	@$(REBAR) escriptize
 
 ct:
 	./scripts/generate_emakefile.escript

--- a/src/protobuffs.erl
+++ b/src/protobuffs.erl
@@ -27,7 +27,7 @@
 -module(protobuffs).
 
 %% Public
--export([encode/3, encode_packed/3, decode/2, decode_packed/2]).
+-export([main/1, encode/3, encode_packed/3, decode/2, decode_packed/2]).
 
 %% Used by generated *_pb file. Not intended to used by User
 -export([next_field_num/1, skip_next_field/1]).
@@ -52,6 +52,14 @@
 		      unit64 | sint32 | sint64 | fixed32 |
 		      sfixed32 | fixed64 | sfixed64 | string |
 		      bytes | float | double.
+
+%%--------------------------------------------------------------------
+%% @doc Runs command line utility
+%% @end
+%%--------------------------------------------------------------------
+
+main(Args) ->
+    protobuffs_cli:main(Args).
 
 %%--------------------------------------------------------------------
 %% @doc Encode an Erlang data structure into a Protocol Buffers value.

--- a/src/protobuffs_cli.erl
+++ b/src/protobuffs_cli.erl
@@ -1,6 +1,6 @@
-#!/usr/bin/env escript
-%% -*- erlang -*-
-%%! -sasl errlog_type error -boot start_sasl -noshell
+-module(protobuffs_cli).
+
+-export([main/1]).
 
 main ([File]) ->
   protobuffs_compile:generate_source (File);

--- a/src/protobuffs_compile.erl
+++ b/src/protobuffs_compile.erl
@@ -141,8 +141,8 @@ output(Basename, MessagesRaw, RawEnums, Options) ->
 
     error_logger:info_msg("Writing header file to ~p~n",[HeaderFile]),
     ok = write_header_include_file(HeaderFile, Messages),
-    PokemonBeamFile = code:where_is_file("pokemon_pb.beam"),
-    {ok,{_,[{abstract_code,{_,Forms}}]}} = beam_lib:chunks(PokemonBeamFile, [abstract_code]),
+    {pokemon_pb, Binary, _} = code:get_object_code(pokemon_pb),
+    {ok,{_,[{abstract_code,{_,Forms}}]}} = beam_lib:chunks(Binary, [abstract_code]),
     Forms1 = filter_forms(Messages, Enums, Forms, Basename, []),
     {ok, _, Bytes, _Warnings} = protobuffs_file:compile_forms(Forms1, proplists:get_value(compile_flags,Options,[])),
     BeamFile = case proplists:get_value(output_ebin_dir,Options) of
@@ -165,8 +165,8 @@ output_source(Basename, MessagesRaw, Enums, Options) ->
     end,
     error_logger:info_msg("Writing header file to ~p~n",[HeaderFile]),
     ok = write_header_include_file(HeaderFile, Messages),
-    PokemonBeamFile = filename:dirname(code:which(?MODULE)) ++ "/pokemon_pb.beam",
-    {ok,{_,[{abstract_code,{_,Forms}}]}} = beam_lib:chunks(PokemonBeamFile, [abstract_code]),
+    {pokemon_pb, Binary, _} = code:get_object_code(pokemon_pb),
+    {ok,{_,[{abstract_code,{_,Forms}}]}} = beam_lib:chunks(Binary, [abstract_code]),
     Forms1 = filter_forms(Messages, Enums, Forms, Basename, []),
     SrcFile = case proplists:get_value(output_src_dir,Options) of
 	undefined ->


### PR DESCRIPTION
There is a new build artifact — protobuffs, which is a self contained escript running a compiler for specified proto file. A code from ./bin/protoc-erl was reused, I just had to fix issues prevented loading pokemon_pb module from escript archive.