### PR TITLE
export int_to_enum/2 and enum_to_int/2

### DIFF
--- a/src/pokemon_pb.erl
+++ b/src/pokemon_pb.erl
@@ -28,6 +28,7 @@
          set_extension/3]).
 -export([decode_extensions/1]).
 -export([encode/1, decode/2, delimited_decode/2]).
+-export([int_to_enum/2, enum_to_int/2]).
 -record(pikachu, {abc, def, '$extensions' = dict:new()}).
 
 %% ENCODE

--- a/src/protobuffs_compile.erl
+++ b/src/protobuffs_compile.erl
@@ -276,11 +276,7 @@ filter_forms(Msgs, Enums, [{function,L,to_record,2,[Clause]}|Tail], Basename, Ac
     filter_forms(Msgs, Enums, Tail, Basename, [expand_to_record_function(Msgs, L, Clause)|Acc]);
 
 filter_forms(Msgs, Enums, [{function,L,enum_to_int,2,[Clause]}|Tail], Basename, Acc) ->
-    Acc2 = case any_message_has_fields(Msgs) orelse any_message_has_extentions(Msgs) of
-        true -> [expand_enum_to_int_function(Enums,L,Clause)|Acc];
-        false -> Acc
-    end,
-    filter_forms(Msgs, Enums, Tail, Basename, Acc2);
+    filter_forms(Msgs, Enums, Tail, Basename, [expand_enum_to_int_function(Enums, L, Clause)|Acc]);
 
 filter_forms(Msgs, Enums, [{function,L,int_to_enum,2,[Clause]}|Tail], Basename, Acc) ->
     filter_forms(Msgs, Enums, Tail, Basename, [expand_int_to_enum_function(Enums, L, Clause)|Acc]);

--- a/test/protobuffs_compile_tests.erl
+++ b/test/protobuffs_compile_tests.erl
@@ -77,3 +77,10 @@ parse_empty_message_test_() ->
         (protobuffs_compile:scan_string("message Dummy { extensions 100 to 200; }", "dummy", [{compile_flags, [warnings_as_errors]}]))),
       ?_assertMatch(ok,
         (protobuffs_compile:scan_string("message Dummy { extentions 100 to max; }", "dummy", [{compile_flags, [warnings_as_errors]}])))]}.
+
+parse_enum_test() ->
+    {foreach, fun setup/0, fun cleanup/1,
+     [?_assertMatch(ok,
+        (protobuffs_compile:scan_string("message Dummy { enum Type { A = 10}}", "dummy", [{compile_flags, [warnings_as_errors]}]))),
+      ?_assertMatch(10, dummy_pb:enum_to_int(dummy_type, 'A')),
+      ?_assertMatch('A', dummy_pb:int_to_enum(dummy_type, 10))]}.


### PR DESCRIPTION
`int_to_enum/2` and `enum_to_int/2` is very useful for the end users in many
cases. Many other languages provide such functions, too.
