### PR TITLE
update meck to 0.8.1p1 for otp 17.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {deps,[
-       {meck, "0.8.1", {git, "git://github.com/basho/meck.git", {tag, "0.8.1"}}}
+       {meck, "0.8.*", {git, "git://github.com/basho/meck.git", {tag, "0.8.1p1"}}}
       ]}.
 
 {clean_files, ["*~","**/*~","**/*.beam","logs/*","test/Emakefile"]}.


### PR DESCRIPTION
will be tagged as `0.8.1p4` after this got merged.
