### PR TITLE
Make meck just a test dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,17 @@ get-deps:
 compile:
 	@$(REBAR) compile
 
+test-deps:
+	@$(REBAR) -C rebar.test.config get-deps compile
+
 ct:
 	./scripts/generate_emakefile.escript
-	@$(REBAR) skip_deps=true ct
+	@$(REBAR) -C rebar.test.config skip_deps=true ct
 
 eunit:
-	@$(REBAR) skip_deps=true eunit
+	@$(REBAR) -C rebar.test.config skip_deps=true eunit
 
-test: eunit ct
+test: test-deps eunit ct
 
 clean:
 	@$(REBAR) clean

--- a/rebar.test.config
+++ b/rebar.test.config
@@ -1,5 +1,9 @@
 {erl_opts, [debug_info]}.
 
+{deps,[
+       {meck, "0.8.*", {git, "git://github.com/basho/meck.git", {tag, "0.8.1p1"}}}
+      ]}.
+
 {clean_files, ["*~","**/*~","**/*.beam","logs/*","test/Emakefile"]}.
 
 {cover_enabled, true}.


### PR DESCRIPTION
This change will make `meck` a test dependency only. It won't spread it for projects that use `erlang_protobuffs` and do not need `meck` as a dependency.

* Move meck to `rebar.test.config`;
* Change Makefile to use `rebar.test.config` when testing.

Is it something desirable? 