### PR TITLE
use meck 0.8.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {deps,[
-       {meck, "0.8.*", {git, "git://github.com/basho/meck.git", {tag, "0.8.1p1"}}}
+       {meck, "0.8.*", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}}
       ]}.
 
 {clean_files, ["*~","**/*~","**/*.beam","logs/*","test/Emakefile"]}.


### PR DESCRIPTION
meck 0.8.1p1 seems no longer available (See [tags](https://github.com/eproxus/meck/tags) for meck, as `rebar updatde-deps` fails for me with `0.8.1p1` spcec in `rebar.config`.

All test run ok with meck `0.8.2`