### PR TITLE
optimize execute efficiency

### DIFF
--- a/src/pokemon_pb.erl
+++ b/src/pokemon_pb.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2009
+%% Copyright (c) 2009 
 %% Nick Gerakines <nick@gerakines.net>
 %% Jacob Vorreuter <jacob.vorreuter@gmail.com>
 %%
@@ -23,278 +23,102 @@
 %% FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 %% OTHER DEALINGS IN THE SOFTWARE.
 -module(pokemon_pb).
--export([encode_pikachu/1, decode_pikachu/1, delimited_decode_pikachu/1]).
--export([has_extension/2, extension_size/1, get_extension/2,
-         set_extension/3]).
--export([decode_extensions/1]).
--export([encode/1, decode/2, delimited_decode/2]).
--export([int_to_enum/2, enum_to_int/2]).
--record(pikachu, {abc, def, '$extensions' = dict:new()}).
+-export([encode_pikachu/1, decode_pikachu/1,encode/1,decode/2]).
+-record(pikachu, {abc, def}).
+
+encode(Record) ->
+    encode(erlang:element(1,Record), Record).
 
 %% ENCODE
-encode([]) ->
-    [];
-encode(Records) when is_list(Records) ->
-    delimited_encode(Records);
-encode(Record) ->
-    encode(element(1, Record), Record).
-
-encode_pikachu(Records) when is_list(Records) ->
-    delimited_encode(Records);
 encode_pikachu(Record) when is_record(Record, pikachu) ->
     encode(pikachu, Record).
 
-encode(pikachu, Records) when is_list(Records) ->
-    delimited_encode(Records);
 encode(pikachu, Record) ->
-    [iolist(pikachu, Record)|encode_extensions(Record)].
+    iolist_to_binary([
+        pack(1, required, with_default(Record#pikachu.abc, none), string, [])
+    ]).
 
-encode_extensions(#pikachu{'$extensions' = Extends}) ->
-    [pack(Key, Optionalness, Data, Type, Accer) ||
-        {Key, {Optionalness, Data, Type, Accer}} <- dict:to_list(Extends)];
-encode_extensions(_) -> [].
-
-delimited_encode(Records) ->
-    lists:map(fun(Record) ->
-        IoRec = encode(Record),
-        Size = iolist_size(IoRec),
-        [protobuffs:encode_varint(Size), IoRec]
-    end, Records).
-
-iolist(pikachu, Record) ->
-    [pack(1, required, with_default(Record#pikachu.abc, none), string, [])].
-
-with_default(Default, Default) -> undefined;
+with_default(undefined, none) -> undefined;
+with_default(undefined, Default) -> Default;
 with_default(Val, _) -> Val.
 
 pack(_, optional, undefined, _, _) -> [];
 
 pack(_, repeated, undefined, _, _) -> [];
-
-pack(_, repeated_packed, undefined, _, _) -> [];
-pack(_, repeated_packed, [], _, _) -> [];
-
+    
 pack(FNum, required, undefined, Type, _) ->
     exit({error, {required_field_is_undefined, FNum, Type}});
 
-pack(_, repeated, [], _, Acc) ->
+pack(_, repeated, [], _, Acc) -> 
     lists:reverse(Acc);
 
 pack(FNum, repeated, [Head|Tail], Type, Acc) ->
     pack(FNum, repeated, Tail, Type, [pack(FNum, optional, Head, Type, [])|Acc]);
 
-pack(FNum, repeated_packed, Data, Type, _) ->
-    protobuffs:encode_packed(FNum, Data, Type);
-
 pack(FNum, _, Data, _, _) when is_tuple(Data) ->
-    [RecName|_] = tuple_to_list(Data),
+%%    [RecName|_] = tuple_to_list(Data),
+	RecName = erlang:element(1,Data),
     protobuffs:encode(FNum, encode(RecName, Data), bytes);
+pack(FNum, _, Data, Type, _) ->
+    protobuffs:encode(FNum, Data, Type).
 
-pack(FNum, _, Data, Type, _) when Type=:=bool;Type=:=int32;Type=:=uint32;
-                  Type=:=int64;Type=:=uint64;Type=:=sint32;
-                  Type=:=sint64;Type=:=fixed32;Type=:=sfixed32;
-                  Type=:=fixed64;Type=:=sfixed64;Type=:=string;
-                  Type=:=bytes;Type=:=float;Type=:=double ->
-    protobuffs:encode(FNum, Data, Type);
 
-pack(FNum, _, Data, Type, _) when is_atom(Data) ->
-    protobuffs:encode(FNum, enum_to_int(Type,Data), enum).
-
-enum_to_int(pikachu,value) ->
-    1.
-
-int_to_enum(_,Val) ->
-    Val.
 
 %% DECODE
-decode_pikachu(Bytes) when is_binary(Bytes) ->
+decode_pikachu(Bytes) ->
     decode(pikachu, Bytes).
-
-delimited_decode_pikachu(Bytes) ->
-    delimited_decode(pikachu, Bytes).
-
-delimited_decode(Type, Bytes) when is_binary(Bytes) ->
-    delimited_decode(Type, Bytes, []).
-
-delimited_decode(_Type, <<>>, Acc) ->
-    {lists:reverse(Acc), <<>>};
-delimited_decode(Type, Bytes, Acc) ->
-    try protobuffs:decode_varint(Bytes) of
-        {Size, Rest} when size(Rest) < Size ->
-            {lists:reverse(Acc), Bytes};
-        {Size, Rest} ->
-            <<MessageBytes:Size/binary, Rest2/binary>> = Rest,
-            Message = decode(Type, MessageBytes),
-            delimited_decode(Type, Rest2, [Message | Acc])
-    catch
-        % most likely cause is there isn't a complete varint in the buffer.
-        _What:_Why ->
-            {lists:reverse(Acc), Bytes}
-    end.
-
-decode(pikachu, Bytes) when is_binary(Bytes) ->
+    
+decode(pikachu, Bytes) ->
     Types = [{1, abc, int32, []}, {2, def, double, []}],
-    Defaults = [],
-    Decoded = decode(Bytes, Types, Defaults),
+    Decoded = decode(Bytes, Types, []),
     to_record(pikachu, Decoded).
-
-decode(<<>>, Types, Acc) -> reverse_repeated_fields(Acc, Types);
-decode(Bytes, Types, Acc) ->
-    {ok, FNum} = protobuffs:next_field_num(Bytes),
-    case lists:keyfind(FNum, 1, Types) of
-        {FNum, Name, Type, Opts} ->
-            {Value1, Rest1} =
+    
+decode(<<>>, _, Acc) -> Acc;
+decode(<<Bytes/binary>>, Types, Acc) ->
+    {{FNum, WireType}, Rest} = protobuffs:read_field_num_and_wire_type(Bytes),
+    case lists:keysearch(FNum, 1, Types) of
+        {value, {FNum, Name, Type, Opts}} ->
+            {Value1, Rest1} = 
                 case lists:member(is_record, Opts) of
                     true ->
-                        {{FNum, V}, R} = protobuffs:decode(Bytes, bytes),
+                        {V, R} = protobuffs:decode_value(WireType, bytes, Rest),
                         RecVal = decode(Type, V),
                         {RecVal, R};
                     false ->
-                        case lists:member(repeated_packed, Opts) of
-                            true ->
-                            {{FNum, V}, R} = protobuffs:decode_packed(Bytes, Type),
-                            {V, R};
-                            false ->
-                            {{FNum, V}, R} = protobuffs:decode(Bytes, Type),
-                            {unpack_value(V, Type), R}
-                        end
+                        {V, R} = protobuffs:decode_value(WireType, Type, Rest),
+                        {unpack_value(V, Type), R}
                 end,
             case lists:member(repeated, Opts) of
                 true ->
                     case lists:keytake(FNum, 1, Acc) of
                         {value, {FNum, Name, List}, Acc1} ->
-                            decode(Rest1, Types, [{FNum, Name, [int_to_enum(Type,Value1)|List]}|Acc1]);
+                            decode(Rest1, Types, [{FNum, Name, lists:reverse([Value1|lists:reverse(List)])}|Acc1]);
                         false ->
-                            decode(Rest1, Types, [{FNum, Name, [int_to_enum(Type,Value1)]}|Acc])
+                            decode(Rest1, Types, [{FNum, Name, [Value1]}|Acc])
                     end;
                 false ->
-                    decode(Rest1, Types, [{FNum, Name, int_to_enum(Type,Value1)}|Acc])
+                    decode(Rest1, Types, [{FNum, Name, Value1}|Acc])
             end;
         false ->
-            case lists:keyfind('$extensions', 2, Acc) of
-                {_,_,Dict} ->
-                    {{FNum, _V}, R} = protobuffs:decode(Bytes, bytes),
-                    Diff = size(Bytes) - size(R),
-                    <<V:Diff/binary,_/binary>> = Bytes,
-                    NewDict = dict:store(FNum, V, Dict),
-                    NewAcc = lists:keyreplace('$extensions', 2, Acc, {false, '$extensions', NewDict}),
-                    decode(R, Types, NewAcc);
-                _ ->
-                    {ok, Skipped} = protobuffs:skip_next_field(Bytes),
-                    decode(Skipped, Types, Acc)
-            end
+            exit({error, {unexpected_field_index, FNum}})
     end.
-
-reverse_repeated_fields(FieldList, Types) ->
-    [ begin
-          case lists:keyfind(FNum, 1, Types) of
-              {FNum, Name, _Type, Opts} ->
-                  case lists:member(repeated, Opts) of
-                      true ->
-                          {FNum, Name, lists:reverse(Value)};
-                      _ ->
-                          Field
-                  end;
-              _ -> Field
-          end
-      end || {FNum, Name, Value}=Field <- FieldList ].
-
-unpack_value(Binary, string) when is_binary(Binary) ->
+    
+unpack_value(<<Binary/binary>>, string) ->
     binary_to_list(Binary);
 unpack_value(Value, _) -> Value.
-
+    
 to_record(pikachu, DecodedTuples) ->
-    Record1 = lists:foldr(
+    lists:foldl(
         fun({_FNum, Name, Val}, Record) ->
             set_record_field(record_info(fields, pikachu), Record, Name, Val)
-        end, #pikachu{}, DecodedTuples),
-    decode_extensions(Record1).
-
-decode_extensions(#pikachu{'$extensions' = Extensions} = Record) ->
-    Types = [],
-    NewExtensions = decode_extensions(Types, dict:to_list(Extensions), []),
-    Record#pikachu{'$extensions' = NewExtensions};
-decode_extensions(Record) ->
-    Record.
-
-decode_extensions(_Types, [], Acc) ->
-    dict:from_list(Acc);
-decode_extensions(Types, [{Fnum, Bytes} | Tail], Acc) ->
-    NewAcc = case lists:keyfind(Fnum, 1, Types) of
-        {Fnum, Name, Type, Opts} ->
-            {Value1, Rest1} =
-                case lists:member(is_record, Opts) of
-                    true ->
-                        {{FNum, V}, R} = protobuffs:decode(Bytes, bytes),
-                        RecVal = decode(Type, V),
-                        {RecVal, R};
-                    false ->
-                        case lists:member(repeated_packed, Opts) of
-                            true ->
-                                {{FNum, V}, R} = protobuffs:decode_packed(Bytes, Type),
-                                {V, R};
-                            false ->
-                                {{FNum, V}, R} = protobuffs:decode(Bytes, Type),
-                                {unpack_value(V, Type), R}
-                        end
-                end,
-            case lists:member(repeated, Opts) of
-                true ->
-                    case lists:keytake(FNum, 1, Acc) of
-                        {value, {FNum, Name, List}, Acc1} ->
-                            decode(Rest1, Types, [{FNum, Name, lists:reverse([int_to_enum(Type,Value1)|lists:reverse(List)])}|Acc1]);
-                        false ->
-                            decode(Rest1, Types, [{FNum, Name, [int_to_enum(Type,Value1)]}|Acc])
-                    end;
-                false ->
-                    [{Fnum, {optional, int_to_enum(Type,Value1), Type, Opts}} | Acc]
-            end;
-        false ->
-            [{Fnum, Bytes} | Acc]
-    end,
-    decode_extensions(Types, Tail, NewAcc).
-
-set_record_field(Fields, Record, '$extensions', Value) ->
-        Decodable = [],
-    NewValue = decode_extensions(element(1, Record), Decodable, dict:to_list(Value)),
-        Index = list_index('$extensions', Fields),
-        erlang:setelement(Index+1,Record,NewValue);
+        end, #pikachu{}, DecodedTuples).
+        
 set_record_field(Fields, Record, Field, Value) ->
     Index = list_index(Field, Fields),
     erlang:setelement(Index+1, Record, Value).
-
-list_index(Target, List) ->  list_index(Target, List, 1).
+    
+list_index(Target, List) -> list_index(Target, List, 1).
 
 list_index(Target, [Target|_], Index) -> Index;
 list_index(Target, [_|Tail], Index) -> list_index(Target, Tail, Index+1);
-list_index(_, [], _) -> -1.
-
-extension_size(#pikachu{'$extensions' = Extensions}) ->
-    dict:size(Extensions);
-extension_size(_) ->
-    0.
-
-has_extension(#pikachu{'$extensions' = Extensions}, FieldKey) ->
-    dict:is_key(FieldKey, Extensions);
-has_extension(_Record, _FieldName) ->
-    false.
-
-get_extension(Record, fieldatom) when is_record(Record, pikachu) ->
-    get_extension(Record, 1);
-get_extension(#pikachu{'$extensions' = Extensions}, Int) when is_integer(Int) ->
-    case dict:find(Int, Extensions) of
-        {ok, {_Rule, Value, _Type, _Opts}} ->
-            {ok, Value};
-        {ok, Binary} ->
-            {raw, Binary};
-         error ->
-             undefined
-     end;
-get_extension(_Record, _FieldName) ->
-    undefined.
-
-set_extension(#pikachu{'$extensions' = Extensions} = Record, fieldname, Value) ->
-    NewExtends = dict:store(1, {rule, Value, type, []}, Extensions),
-    {ok, Record#pikachu{'$extensions' = NewExtends}};
-set_extension(Record, _, _) ->
-    {error, Record}.
+list_index(_, [], _) -> 0.

--- a/src/protobuffs.erl
+++ b/src/protobuffs.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2009
+%% Copyright (c) 2009 
 %% Nick Gerakines <nick@gerakines.net>
 %% Jacob Vorreuter <jacob.vorreuter@gmail.com>
 %%
@@ -25,18 +25,9 @@
 %%
 %% @doc A protcol buffers encoding and decoding module.
 -module(protobuffs).
-
-%% Public
--export([encode/3, encode_packed/3, decode/2, decode_packed/2]).
-
-%% Used by generated *_pb file. Not intended to used by User
--export([next_field_num/1, skip_next_field/1]).
--export([encode_varint/1, decode_varint/1]).
-
-%% Will be removed from export, only intended for internal usage
--deprecated([{read_field_num_and_wire_type,1,next_version}]).
--deprecated([{decode_value,3,next_version}]).
--export([read_field_num_and_wire_type/1, decode_value/3]).
+-export([encode/3, read_field_num_and_wire_type/1, decode/2, decode_value/3]).
+%-compile(export_all).
+%-compile({inline_size,100}).
 
 -define(TYPE_VARINT, 0).
 -define(TYPE_64BIT, 1).
@@ -45,356 +36,231 @@
 -define(TYPE_END_GROUP, 4).
 -define(TYPE_32BIT, 5).
 
--type encoded_field_type() ::
-	?TYPE_VARINT | ?TYPE_64BIT | ?TYPE_STRING |
-	?TYPE_START_GROUP | ?TYPE_END_GROUP | ?TYPE_32BIT.
 
--type field_type() :: bool | enum | int32 | uint32 | int64 |
-		      unit64 | sint32 | sint64 | fixed32 |
-		      sfixed32 | fixed64 | sfixed64 | string |
-		      bytes | float | double.
-
-%%--------------------------------------------------------------------
+%% @spec encode(FieldID, Value, Type) -> Result
+%%       FieldID = integer()
+%%       Value = any()
+%%       Type = bool | enum | int32 | uint32 | int64 | uint64 | sint32 | sint64 | fixed32 | sfixed32 | fixed64 | sfixed64 | string | bytes | float | double 
+%%       Result = list()
 %% @doc Encode an Erlang data structure into a Protocol Buffers value.
-%% @end
-%%--------------------------------------------------------------------
--spec encode(FieldID :: non_neg_integer(),
-	     Value :: any(),
-	     Type :: field_type()) ->
-		    iodata().
 encode(FieldID, Value, Type) ->
-    encode_internal(FieldID, Value, Type).
+%%    iolist_to_binary(encode_internal(FieldID, Value, Type)).
+    encode_internal(Type, FieldID, Value).
 
-%%--------------------------------------------------------------------
-%% @doc Encode an list of Erlang data structure into a Protocol Buffers values.
-%% @end
-%%--------------------------------------------------------------------
--spec encode_packed(FieldID :: non_neg_integer(),
-		    Values :: list(),
-		    Type :: field_type()) ->
-			   binary().
-encode_packed(_FieldID, [], _Type) ->
-    <<>>;
-encode_packed(FieldID, Values, Type) ->
-    PackedValues = encode_packed_internal(Values,Type,[]),
-    Size = encode_varint(iolist_size(PackedValues)),
-    [encode_field_tag(FieldID, ?TYPE_STRING),Size,PackedValues].
-
-%% @hidden
--spec encode_internal(FieldID :: non_neg_integer(),
-		      Value :: any(),
-		      Type :: field_type()) ->
-			     iolist().
-encode_internal(FieldID, false, bool) ->
-    encode_internal(FieldID, 0, int32);
-encode_internal(FieldID, true, bool) ->
-    encode_internal(FieldID, 1, int32);
-encode_internal(FieldID, Integer, enum) when is_integer(Integer) ->
-    encode_internal(FieldID, Integer, int32);
-encode_internal(FieldID, Integer, int32) when Integer >= -16#80000000,
-					      Integer < 0 ->
-    encode_internal(FieldID, Integer, int64);
-encode_internal(FieldID, Integer, int64) when Integer >= -16#8000000000000000,
-					      Integer < 0 ->
-    encode_internal(FieldID, Integer + (1 bsl 64), uint64);
-encode_internal(FieldID, Integer, int32) when is_integer(Integer),
-					      Integer >= -16#80000000,
-					      Integer =< 16#7fffffff ->
-    encode_varint_field(FieldID, Integer);
-encode_internal(FieldID, Integer, uint32) when Integer band 16#ffffffff =:= Integer ->
-    encode_varint_field(FieldID, Integer);
-encode_internal(FieldID, Integer, int64) when is_integer(Integer),
-					      Integer >= -16#8000000000000000,
-					      Integer =< 16#7fffffffffffffff ->
-    encode_varint_field(FieldID, Integer);
-encode_internal(FieldID, Integer, uint64) when Integer band 16#ffffffffffffffff =:= Integer ->
-    encode_varint_field(FieldID, Integer);
-encode_internal(FieldID, Integer, bool) when Integer =:= 1; Integer =:= 0 ->
-    encode_varint_field(FieldID, Integer);
-encode_internal(FieldID, Integer, sint32) when is_integer(Integer),
-					       Integer >= -16#80000000,
-					       Integer < 0 ->
-    encode_varint_field(FieldID, bnot (Integer bsl 1));
-encode_internal(FieldID, Integer, sint64) when is_integer(Integer),
-					       Integer >= -16#8000000000000000,
-					       Integer < 0 ->
-    encode_varint_field(FieldID, bnot (Integer bsl 1));
-encode_internal(FieldID, Integer, sint32) when is_integer(Integer),
-					       Integer >= 0,
-					       Integer =< 16#7fffffff ->
-    encode_varint_field(FieldID, Integer bsl 1);
-encode_internal(FieldID, Integer, sint64) when is_integer(Integer),
-					       Integer >= 0,
-					       Integer =< 16#7fffffffffffffff ->
-    encode_varint_field(FieldID, Integer bsl 1);
-encode_internal(FieldID, Integer, fixed32) when Integer band 16#ffffffff =:= Integer ->
-    [encode_field_tag(FieldID, ?TYPE_32BIT), <<Integer:32/little-integer>>];
-encode_internal(FieldID, Integer, sfixed32) when Integer >= -16#80000000,
-						 Integer =< 16#7fffffff ->
-    [encode_field_tag(FieldID, ?TYPE_32BIT), <<Integer:32/little-integer>>];
-encode_internal(FieldID, Integer, fixed64) when Integer band 16#ffffffffffffffff =:= Integer ->
-    [encode_field_tag(FieldID, ?TYPE_64BIT), <<Integer:64/little-integer>>];
-encode_internal(FieldID, Integer, sfixed64) when Integer >= -16#8000000000000000,
-						 Integer =< 16#7fffffffffffffff ->
-    [encode_field_tag(FieldID, ?TYPE_64BIT), <<Integer:64/little-integer>>];
-encode_internal(FieldID, String, string) when is_list(String) ->
-    encode_internal(FieldID, unicode:characters_to_binary(String), string);
-encode_internal(FieldID, String, string) when is_binary(String) ->
-    encode_internal(FieldID, String, bytes);
-encode_internal(FieldID, Bytes, bytes) when is_binary(Bytes); is_list(Bytes) ->
-    [encode_field_tag(FieldID, ?TYPE_STRING), encode_varint(iolist_size(Bytes)), Bytes];
-encode_internal(FieldID, Float, float) when is_integer(Float) ->
-    encode_internal(FieldID, Float + 0.0, float);
-encode_internal(FieldID, Float, float) when is_float(Float) ->
-    [encode_field_tag(FieldID, ?TYPE_32BIT), <<Float:32/little-float>>];
-encode_internal(FieldID, nan, float) ->
-    [encode_field_tag(FieldID, ?TYPE_32BIT), <<0:16,192:8,255:8>>];
-encode_internal(FieldID, infinity, float) ->
-    [encode_field_tag(FieldID, ?TYPE_32BIT), <<0:16,128:8,127:8>>];
-encode_internal(FieldID, '-infinity', float) ->
-    [encode_field_tag(FieldID, ?TYPE_32BIT), <<0:16,128:8,255:8>>];
-encode_internal(FieldID, Float, double) when is_integer(Float) ->
-    encode_internal(FieldID, Float + 0.0, double);
-encode_internal(FieldID, Float, double) when is_float(Float) ->
-    [encode_field_tag(FieldID, ?TYPE_64BIT), <<Float:64/little-float>>];
-encode_internal(FieldID, nan, double) ->
-    [encode_field_tag(FieldID, ?TYPE_64BIT), <<0:48,16#F8,16#FF>>];
-encode_internal(FieldID, infinity, double) ->
-    [encode_field_tag(FieldID, ?TYPE_64BIT), <<0:48,16#F0,16#7F>>];
-encode_internal(FieldID, '-infinity', double) ->
-    [encode_field_tag(FieldID, ?TYPE_64BIT), <<0:48,16#F0,16#FF>>];
-encode_internal(FieldID, Value, Type) ->
-    erlang:error(badarg,[FieldID, Value, Type]).
-
+-define(encode_field_tag(FieldID, FieldType), 
+	case FieldID band 16#3fffffff of
+		FieldID ->
+			encode_varint((FieldID bsl 3) bor FieldType); 
+		_ ->
+			exit({error, {encode_field_tag, FieldID, FieldType}})
+	end).
+-define(encode_internal_bytes(FieldID, Bytes), [?encode_field_tag(FieldID, ?TYPE_STRING), encode_varint(size(Bytes)), Bytes]).
+-define(encode_varint_field(FieldID, Integer), [?encode_field_tag(FieldID, ?TYPE_VARINT), encode_varint(Integer)]).
+-define(encode_internal_float(FieldID, Float, Type, Bit),
+	Float1 = case is_float(Float) of
+		true -> Float;
+		_ ->
+			case is_integer(Float) of
+				true -> Float + 0.0;
+				_ -> exit({error, {encode_internal, float_or_double, FieldID, Float}})
+			end
+	end,
+	[?encode_field_tag(FieldID, Type), <<Float1:Bit/little-float>>]).
 
 %% @hidden
--spec encode_packed_internal(Values :: list(),
-			     ExpectedType :: field_type(),
-			     Acc :: list()) ->
-				    iolist().
-encode_packed_internal([],_Type,Acc) ->
-    lists:reverse(Acc);
-encode_packed_internal([Value|Tail], ExpectedType, Acc) ->
-    [_|V] = encode_internal(1, Value, ExpectedType),
-    encode_packed_internal(Tail, ExpectedType, [V|Acc]).
+encode_internal(bytes, FieldID, <<Bytes/binary>>) ->
+    ?encode_internal_bytes(FieldID, Bytes);
+encode_internal(bytes, FieldID, []) ->
+    ?encode_internal_bytes(FieldID, <<>>);
+encode_internal(bytes, FieldID, String=[_|_]) ->
+    ?encode_internal_bytes(FieldID, list_to_binary(String));
+encode_internal(string, FieldID, []) ->
+	?encode_internal_bytes(FieldID, <<>>);
+encode_internal(string, FieldID, String = [_|_]) ->
+    ?encode_internal_bytes(FieldID, list_to_binary(String));
+encode_internal(string, FieldID, <<Binary/binary>>) ->
+    ?encode_internal_bytes(FieldID, Binary);
+encode_internal(uint32, FieldID, Integer) ->
+	case Integer band 16#ffffffff of
+		Integer ->
+			?encode_varint_field(FieldID, Integer);
+		_ ->
+			exit({error, {encode_internal, uint32, FieldID, Integer}})
+	end;
+encode_internal(bool, FieldID, false) ->
+    encode_internal(int32, FieldID, 0);
+encode_internal(bool, FieldID, true) ->
+    encode_internal(int32, FieldID, 1);
+encode_internal(enum, FieldID, Integer) ->
+    encode_internal(uint32, FieldID, Integer);
+encode_internal(int32, FieldID, Integer) ->
+	if Integer >= 0 andalso Integer =< 16#7fffffff ->
+			?encode_varint_field(FieldID, Integer);
+		Integer >= -16#80000000 andalso Integer < 0 ->
+			encode_internal(int64, FieldID, Integer);
+		true ->
+			exit({error, {encode_internal, int32, FieldID, Integer}})
+	end;
+encode_internal(int64, FieldID, Integer) ->
+	if Integer >= 0 andalso Integer =< 16#7fffffffffffffff ->
+			?encode_varint_field(FieldID, Integer);
+		Integer >= -16#8000000000000000 andalso Integer < 0 ->
+			encode_internal(uint64, FieldID, Integer + (1 bsl 64));
+		true ->
+			exit({error, {encode_internal, int64, FieldID, Integer}})
+	end;
+encode_internal(uint64, FieldID, Integer) ->
+	case Integer band 16#ffffffffffffffff of
+		Integer ->
+			?encode_varint_field(FieldID, Integer);
+		_ ->
+			exit({error, {encode_internal, uint64, FieldID, Integer}})
+	end;
+encode_internal(bool, FieldID, Integer) ->
+	case Integer band 1 =:= 1 of
+		true ->
+			?encode_varint_field(FieldID, Integer);
+		_ ->
+			exit({error, {encode_internal, bool, FieldID, Integer}})
+	end;
+encode_internal(sint32, FieldID, Integer)  ->
+	if Integer >= 0 andalso Integer =< 16#7fffffff ->
+			?encode_varint_field(FieldID, Integer bsl 1);
+		Integer >= -16#80000000 andalso Integer < 0 ->
+			?encode_varint_field(FieldID, bnot (Integer bsl 1));
+		true ->
+			exit({error, {encode_internal, sint32, FieldID, Integer}})
+	end;
+encode_internal(sint64, FieldID, Integer)  ->
+	if Integer >= 0 andalso Integer =< 16#7fffffffffffffff ->
+			?encode_varint_field(FieldID, Integer bsl 1);
+		Integer >= -16#8000000000000000 andalso Integer < 0 ->
+			?encode_varint_field(FieldID, bnot (Integer bsl 1));
+		true ->
+			exit({error, {encode_internal, sint64, FieldID, Integer}})
+	end;    
+encode_internal(fixed32, FieldID, Integer) ->
+	case Integer band 16#ffffffff of
+		Integer ->
+			[?encode_field_tag(FieldID, ?TYPE_32BIT), << Integer:32/little-integer>>];
+		_ ->
+			exit({error, {encode_internal, fixed32, FieldID, Integer}})
+	end;
+encode_internal(sfixed32, FieldID, Integer)  ->
+	if Integer >= -16#80000000 andalso Integer =< 16#7fffffff ->
+			[?encode_field_tag(FieldID, ?TYPE_32BIT), <<Integer:32/little-integer>>];
+		true ->
+			exit({error, {encode_internal, sfixed32, FieldID, Integer}})
+	end;
+encode_internal(fixed64, FieldID, Integer)  ->
+	case Integer band 16#ffffffffffffffff of
+		Integer ->
+			[?encode_field_tag(FieldID, ?TYPE_64BIT),  << Integer:64/little-integer>>];
+		_ ->
+			exit({error, {encode_internal, fixed64, FieldID, Integer}})
+	end;
+encode_internal(sfixed64, FieldID, Integer) ->
+	if Integer >= -16#8000000000000000 andalso Integer =< 16#7fffffffffffffff ->
+			[?encode_field_tag(FieldID, ?TYPE_64BIT),  <<Integer:64/little-integer>>];
+		true ->
+			exit({error, {encode_internal, sfixed64, FieldID, Integer}})
+	end;
+encode_internal(float, FieldID, Float) ->
+	?encode_internal_float(FieldID, Float, ?TYPE_32BIT, 32);
+encode_internal(double, FieldID, Float) ->
+	?encode_internal_float(FieldID, Float, ?TYPE_64BIT, 64).
+	
 
-%%--------------------------------------------------------------------
-%% @doc Will be hidden in future releases
-%% @end
-%%--------------------------------------------------------------------
--spec read_field_num_and_wire_type(Bytes :: binary()) ->
-					  {{non_neg_integer(), encoded_field_type()}, binary()}.
-read_field_num_and_wire_type(<<_:8,_/binary>> = Bytes) ->
+read_field_num_and_wire_type(Bytes) ->
     {Tag, Rest} = decode_varint(Bytes),
     FieldID = Tag bsr 3,
-    case Tag band 7 of
-	?TYPE_VARINT ->
-	    {{FieldID, ?TYPE_VARINT}, Rest};
-	?TYPE_64BIT ->
-	    {{FieldID, ?TYPE_64BIT}, Rest};
-	?TYPE_STRING ->
-	    {{FieldID, ?TYPE_STRING}, Rest};
-	?TYPE_START_GROUP ->
-	    {{FieldID, ?TYPE_START_GROUP}, Rest};
-	?TYPE_END_GROUP ->
-	    {{FieldID, ?TYPE_END_GROUP}, Rest};
-	?TYPE_32BIT ->
-	    {{FieldID, ?TYPE_32BIT}, Rest};
-	_Else ->
-	    erlang:throw({error, "Error decodeing type"})
-    end;
-read_field_num_and_wire_type(Bytes) ->
-    erlang:error(badarg,[Bytes]).
-
-%%--------------------------------------------------------------------
-%% @doc Decode a single value from a protobuffs data structure
-%% @end
-%%--------------------------------------------------------------------
--spec decode(Bytes :: binary(), ExpectedType :: field_type()) ->
-		    {{non_neg_integer(), any()}, binary()}.
+    WireType = Tag band 7,
+    {{FieldID, WireType}, Rest}.
+    
+%% @spec decode(Bytes, ExpectedType) -> Result
+%%       Bytes = binary()
+%%       ExpectedType = bool | enum | int32 | uint32 | int64 | unit64 | sint32 | sint64 | fixed32 | sfixed32 | fixed64 | sfixed64 | string | bytes | float | double 
+%%       Result = {{integer(), any()}, binary()}
 decode(Bytes, ExpectedType) ->
     {{FieldID, WireType}, Rest} = read_field_num_and_wire_type(Bytes),
-    {Value, Rest1} = decode_value(Rest, WireType, ExpectedType),
+    {Value, Rest1} = decode_value(WireType, ExpectedType, Rest),
     {{FieldID, Value}, Rest1}.
 
-%%--------------------------------------------------------------------
-%% @doc Decode packed values from a protobuffs data structure
-%% @end
-%%--------------------------------------------------------------------
--spec decode_packed(Bytes :: binary(), ExpectedType :: field_type()) ->
-			   {{non_neg_integer(), any()}, binary()}.
-decode_packed(Bytes, ExpectedType) ->
-    case read_field_num_and_wire_type(Bytes) of
-	{{FieldID, ?TYPE_STRING}, Rest} ->
-	    {Length, Rest1} = decode_varint(Rest),
-	    {Packed,Rest2} = split_binary(Rest1, Length),
-	    Values = decode_packed_values(Packed, ExpectedType, []),
-	    {{FieldID, Values},Rest2};
-	_Else ->
-	    erlang:error(badarg)
-    end.
-
-%%--------------------------------------------------------------------
-%% @doc Returns the next field number id from a protobuffs data structure
-%% @end
-%%--------------------------------------------------------------------
--spec next_field_num(Bytes :: binary()) -> {ok,non_neg_integer()}.
-next_field_num(Bytes) ->
-    {{FieldID,_WiredType}, _Rest} = read_field_num_and_wire_type(Bytes),
-    {ok,FieldID}.
-
-%%--------------------------------------------------------------------
-%% @doc Skips the field at the front of the message, effectively ignoring it.
-%% @end
-%%--------------------------------------------------------------------
--spec skip_next_field(Bytes :: binary()) ->
-                             {ok, binary()}.
-skip_next_field(Bytes) ->
-    {{_FieldId, WireType}, Rest} = read_field_num_and_wire_type(Bytes),
-    case WireType of
-        ?TYPE_VARINT ->
-            {_, Rest1} = decode_varint(Rest);
-        ?TYPE_64BIT ->
-            <<_:64, Rest1/binary>> = Rest;
-        ?TYPE_32BIT ->
-            <<_:32, Rest1/binary>> = Rest;
-        ?TYPE_STRING ->
-            {_, Rest1} = decode_value(Rest, WireType, string);
-        _ ->
-            Rest1 = Rest
-    end,
-    {ok, Rest1}.
 
 %% @hidden
--spec decode_packed_values(Bytes :: binary(),
-			   Type :: field_type(),
-			   Acc :: list()) ->
-				  iolist().
-decode_packed_values(<<>>, _, Acc) ->
-    lists:reverse(Acc);
-decode_packed_values(Bytes, bool, Acc) ->
-    {Value,Rest} = decode_value(Bytes,?TYPE_VARINT, bool),
-    decode_packed_values(Rest, bool, [Value|Acc]);
-decode_packed_values(Bytes, enum, Acc) ->
-    {Value,Rest} = decode_value(Bytes,?TYPE_VARINT, enum),
-    decode_packed_values(Rest, enum, [Value|Acc]);
-decode_packed_values(Bytes, int32, Acc) ->
-    {Value,Rest} = decode_value(Bytes,?TYPE_VARINT, int32),
-    decode_packed_values(Rest, int32, [Value|Acc]);
-decode_packed_values(Bytes, uint32, Acc) ->
-    {Value,Rest} = decode_value(Bytes,?TYPE_VARINT, uint32),
-    decode_packed_values(Rest, uint32, [Value|Acc]);
-decode_packed_values(Bytes, sint32, Acc) ->
-    {Value,Rest} = decode_value(Bytes,?TYPE_VARINT, sint32),
-    decode_packed_values(Rest, sint32, [Value|Acc]);
-decode_packed_values(Bytes, int64, Acc) ->
-    {Value,Rest} = decode_value(Bytes,?TYPE_VARINT, int64),
-    decode_packed_values(Rest, int64, [Value|Acc]);
-decode_packed_values(Bytes, uint64, Acc) ->
-    {Value,Rest} = decode_value(Bytes,?TYPE_VARINT, uint64),
-    decode_packed_values(Rest, uint64, [Value|Acc]);
-decode_packed_values(Bytes, sint64, Acc) ->
-    {Value,Rest} = decode_value(Bytes,?TYPE_VARINT, sint64),
-    decode_packed_values(Rest, sint64, [Value|Acc]);
-decode_packed_values(Bytes, float, Acc) ->
-    {Value,Rest} = decode_value(Bytes,?TYPE_32BIT, float),
-    decode_packed_values(Rest, float, [Value|Acc]);
-decode_packed_values(Bytes, double, Acc) ->
-    {Value,Rest} = decode_value(Bytes,?TYPE_64BIT, double),
-    decode_packed_values(Rest, double, [Value|Acc]);
-decode_packed_values(Bytes, Type, Acc) ->
-    erlang:error(badarg,[Bytes,Type,Acc]).
-
-
-%%--------------------------------------------------------------------
-%% @doc Will be hidden in future releases
-%% @end
-%%--------------------------------------------------------------------
--spec decode_value(Bytes :: binary(),
-		   WireType :: encoded_field_type(),
-		   ExpectedType :: field_type()) ->
-			  {any(),binary()}.
-decode_value(Bytes, ?TYPE_VARINT, ExpectedType) ->
+decode_value(?TYPE_VARINT, ExpectedType, Bytes) ->
     {Value, Rest} = decode_varint(Bytes),
-    {typecast(Value, ExpectedType), Rest};
-decode_value(Bytes, ?TYPE_STRING, string) ->
-    {Length, Rest} = decode_varint(Bytes),
-    {Value,Rest1} = split_binary(Rest, Length),
-    {[C || <<C/utf8>> <= Value],Rest1};
-decode_value(Bytes, ?TYPE_STRING, bytes) ->
+    {typecast(ExpectedType, Value), Rest};
+decode_value(?TYPE_STRING, bytes, Bytes) ->
     {Length, Rest} = decode_varint(Bytes),
     split_binary(Rest, Length);
-decode_value(<<Value:64/little-unsigned-integer, Rest/binary>>, ?TYPE_64BIT, fixed64) ->
+decode_value(?TYPE_STRING, string, Bytes) ->
+    {Length, Rest} = decode_varint(Bytes),
+    split_binary(Rest, Length);
+decode_value(?TYPE_64BIT, fixed64, <<Value:64/little-unsigned-integer, Rest/binary>>) ->
     {Value, Rest};
-decode_value(<<Value:32/little-unsigned-integer, _:32, Rest/binary>>, ?TYPE_64BIT, fixed32) ->
+decode_value(?TYPE_64BIT, fixed32, <<Value:32/little-unsigned-integer, _:32, Rest/binary>>) ->
     {Value, Rest};
-decode_value(<<Value:64/little-signed-integer, Rest/binary>>, ?TYPE_64BIT, sfixed64) ->
+decode_value(?TYPE_64BIT, sfixed64, <<Value:64/little-signed-integer, Rest/binary>>) ->
     {Value, Rest};
-decode_value(<<Value:32/little-signed-integer, _:32, Rest/binary>>, ?TYPE_64BIT, sfixed32) ->
+decode_value(?TYPE_64BIT, sfixed32, <<Value:32/little-signed-integer, _:32, Rest/binary>>) ->
     {Value, Rest};
-decode_value(<<Value:32/little-unsigned-integer, Rest/binary>>, ?TYPE_32BIT, Type) when Type =:= fixed32; Type =:= fixed64 ->
+decode_value(?TYPE_32BIT, fixed32, <<Value:32/little-unsigned-integer, Rest/binary>>)  ->
     {Value, Rest};
-decode_value(<<Value:32/little-signed-integer, Rest/binary>>, ?TYPE_32BIT, Type) when Type =:= sfixed32; Type =:= sfixed64 ->
+decode_value(?TYPE_32BIT, fixed64, <<Value:32/little-unsigned-integer, Rest/binary>>) ->
     {Value, Rest};
-decode_value(<<Value:32/little-float, Rest/binary>>, ?TYPE_32BIT, float) ->
+decode_value(?TYPE_32BIT, sfixed32, <<Value:32/little-signed-integer, Rest/binary>>) ->
+    {Value, Rest};
+decode_value(?TYPE_32BIT, sfixed64, <<Value:32/little-signed-integer, Rest/binary>>) ->
+    {Value, Rest};
+decode_value(?TYPE_32BIT, float, <<Value:32/little-float, Rest/binary>>) ->
     {Value + 0.0, Rest};
-decode_value(<<0:16, 128:8, 127:8, Rest/binary>>, ?TYPE_32BIT, float) ->
-    {infinity, Rest};
-decode_value(<<0:16, 128:8, 255:8, Rest/binary>>, ?TYPE_32BIT, float) ->
-    {'-infinity', Rest};
-decode_value(<<_:16, 2#1:1, _:7, _:1, 2#1111111:7, Rest/binary>>, ?TYPE_32BIT, float) ->
-    {nan, Rest};
-decode_value(<<Value:64/little-float, Rest/binary>>, ?TYPE_64BIT, double) ->
+decode_value(?TYPE_64BIT, double, <<Value:64/little-float, Rest/binary>>) ->
     {Value + 0.0, Rest};
-decode_value(<<0:48, 240:8, 127:8, Rest/binary>>, ?TYPE_64BIT, double) ->
-    {infinity, Rest};
-decode_value(<<0:48, 240:8, 255:8, Rest/binary>>, ?TYPE_64BIT, double) ->
-    {'-infinity', Rest};
-decode_value(<<_:48, 2#1111:4, _:4, _:1, 2#1111111:7, Rest/binary>>, ?TYPE_64BIT, double) ->
-    {nan, Rest};
-decode_value(Bytes,WireType,ExpectedType) ->
-    erlang:error(badarg,[Bytes,WireType,ExpectedType]).
+decode_value(WireType, ExpectedType, _) ->
+    exit({error, {unexpected_value, WireType, ExpectedType}}).
 
 %% @hidden
--spec typecast(Value :: any(), Type :: field_type()) ->
-		      any().
-typecast(Value, SignedType) when SignedType =:= int32; SignedType =:= int64; SignedType =:= enum ->
-    if
-        Value band 16#8000000000000000 =/= 0 -> Value - 16#10000000000000000;
+-define(TYPECAST_INT(Value),
+    if Value band 16#8000000000000000 =/= 0 -> Value - 16#10000000000000000;
         true -> Value
+    end).
+%% @hidden
+-define(TYPECAST_SINT(Value),
+    (Value bsr 1) bxor (-(Value band 1))).
+
+%% @hidden
+typecast(int32, Value) ->
+    ?TYPECAST_INT(Value);
+typecast(int64, Value) ->
+    ?TYPECAST_INT(Value);
+typecast(sint32, Value) ->
+    ?TYPECAST_SINT(Value);
+typecast(sint64, Value) ->
+    ?TYPECAST_SINT(Value);
+typecast(bool, Value) ->
+    case Value of
+      1 -> true;
+      _ -> false
     end;
-typecast(Value, SignedType) when SignedType =:= sint32; SignedType =:= sint64 ->
-    (Value bsr 1) bxor (-(Value band 1));
-typecast(Value, Type) when Type =:= bool ->
-    Value =:= 1;
-typecast(Value, _) ->
+typecast(_, Value) ->
     Value.
 
 %% @hidden
--spec encode_field_tag(FieldID :: non_neg_integer(),
-		       FieldType :: encoded_field_type()) ->
-			      iodata().
-encode_field_tag(FieldID, FieldType) when FieldID band 16#3fffffff =:= FieldID ->
-    encode_varint((FieldID bsl 3) bor FieldType).
+%%encode_field_tag(FieldID, FieldType) when FieldID band 16#3fffffff =:= FieldID ->
+%%    encode_varint((FieldID bsl 3) bor FieldType).
 
 %% @hidden
--spec encode_varint_field(FieldID :: non_neg_integer(),
-			  Integer :: integer()) ->
-				 iolist().
-encode_varint_field(FieldID, Integer) ->
-    [encode_field_tag(FieldID, ?TYPE_VARINT), encode_varint(Integer)].
+%%encode_varint_field(FieldID, Integer) ->
+%%    [encode_field_tag(FieldID, ?TYPE_VARINT), encode_varint(Integer)].
 
 %% @hidden
--spec encode_varint(I :: integer()) ->
-			   iodata().
 encode_varint(I) ->
     encode_varint(I, []).
 
 %% @hidden
--spec encode_varint(I :: integer(), Acc :: list()) ->
-			   iodata().
 encode_varint(I, Acc) when I =< 16#7f ->
-    lists:reverse([I | Acc]);
+    iolist_to_binary(lists:reverse([I | Acc]));
 encode_varint(I, Acc) ->
     Last_Seven_Bits = (I - ((I bsr 7) bsl 7)),
     First_X_Bits = (I bsr 7),
@@ -402,17 +268,18 @@ encode_varint(I, Acc) ->
     encode_varint(First_X_Bits, [With_Leading_Bit|Acc]).
 
 %% @hidden
--spec decode_varint(Bytes :: binary()) ->
-			   {integer(), binary()}.
 decode_varint(Bytes) ->
-    decode_varint(Bytes, 0, 0).
+    decode_varint(Bytes, []).
+decode_varint(<<0:1, I:7, Rest/binary>>, Acc) ->
+    Result = decode_varint1([I|Acc], 0),
+    {Result, Rest};
+decode_varint(<<1:1, I:7, Rest/binary>>, Acc) ->
+    decode_varint(Rest, [I | Acc]).
 
 %% @hidden
--spec decode_varint(Bytes :: binary(), non_neg_integer(), non_neg_integer()) ->
-			   {integer(), binary()}.
-decode_varint(<<0:1, I:7, Rest/binary>>, Int, Depth) ->
-    {(I bsl Depth) bor Int, Rest};
-decode_varint(<<1:1, I:7, Rest/binary>>, Int, Depth) ->
-    decode_varint(Rest, (I bsl Depth) bor Int, Depth + 7);
-decode_varint(Bin, Int, Depth) ->
-    erlang:error(badarg, [Bin, Int, Depth]).
+%% decode_varint1(L) ->
+%%     decode_varint1(L, 0).
+decode_varint1([], Acc) ->
+    Acc;
+decode_varint1([X|R], Acc) ->
+    decode_varint1(R, Acc bsl 7 bor X).

--- a/src/protobuffs_compile.erl
+++ b/src/protobuffs_compile.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2009-2013
+%% Copyright (c) 2009 
 %% Nick Gerakines <nick@gerakines.net>
 %% Jacob Vorreuter <jacob.vorreuter@gmail.com>
 %%
@@ -23,520 +23,123 @@
 %% FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 %% OTHER DEALINGS IN THE SOFTWARE.
 -module(protobuffs_compile).
+-export([scan_file/1, output/2, scan_file_src/1]).
 
--ifdef(TEST).
--compile(export_all).
--else.
--export([scan_file/1, scan_file/2, scan_string/2, scan_string/3,
-     generate_source/1, generate_source/2]).
--endif.
-
--record(collected,{enum=[], msg=[], extensions=[], package}).
-
-%%--------------------------------------------------------------------
-%% @doc Generats a built .beam file and header file .hrl
-%%--------------------------------------------------------------------
--spec scan_file(ProtoFile :: string()) ->
-               ok | {error, _}.
-scan_file(ProtoFile) ->
-    scan_file(ProtoFile,[]).
-
--spec scan_string(String :: string(), BaseName :: string()) ->
-             ok | {error, _}.
-scan_string(String,BaseName) ->
-    scan_string(String,BaseName,[]).
-
-%%--------------------------------------------------------------------
-%% @doc Generats a built .beam file and header file .hrl
-%%      Considerd option properties: output_include_dir,
-%%                                   output_ebin_dir,
-%%                                   imports_dir
-%%--------------------------------------------------------------------
--spec scan_file(ProtoFile :: string() | atom(), Options :: list()) ->
-               ok | {error, _}.
-scan_file(ProtoFile,Options) when is_list(ProtoFile) ->
+scan_file(ProtoFile) when is_list(ProtoFile) ->
     Basename = filename:basename(ProtoFile, ".proto") ++ "_pb",
-    {ok,String} = parse_file(ProtoFile),
-    scan_string(String,Basename,Options);
-scan_file(ProtoFile,Options) when is_atom(ProtoFile) ->
-    Basename = atom_to_list(ProtoFile) ++ "_pb",
-    {ok,String} = parse_file(atom_to_list(ProtoFile) ++ ".proto"),
-    scan_string(String,Basename,Options).
+    Parsed = protobuffs_parser:parse_file(ProtoFile),
+    UntypedMessages = collect_full_messages(Parsed),
+    Messages = resolve_types (UntypedMessages),
+    output(Basename, Messages).
 
--spec scan_string(String :: string(), Basename :: string(), Options :: list()) ->
-             ok | {error, _}.
-scan_string(String,Basename,Options) ->
-    {ok,FirstParsed} = parse_string(String),
-    ImportPaths = ["./", "src/" | proplists:get_value(imports_dir, Options, [])],
-    Parsed = parse_imports(FirstParsed, ImportPaths),
-    Collected = collect_full_messages(Parsed),
-    Messages = resolve_types(Collected#collected.msg,Collected#collected.enum),
-    output(Basename, Messages, Collected#collected.enum, Options).
+output(Basename, Messages) ->
+    ok = write_header_include_file(Basename, Messages),
+    BeamFile = filename:dirname(code:which(?MODULE)) ++ "/pokemon_pb.beam",
+	{ok,{_,[{abstract_code,{_,Forms}}]}} =beam_lib:chunks(BeamFile, [abstract_code]),
+    Forms1 = filter_forms(Messages, Forms, Basename, []),
+    {ok, _, Bytes, _Warnings} = compile:forms(Forms1, [return]),
+    file:write_file(Basename ++ ".beam", Bytes).
 
 %%--------------------------------------------------------------------
 %% @doc Generats a source .erl file and header file .hrl
 %%--------------------------------------------------------------------
--spec generate_source(ProtoFile :: string() | atom() ) ->
-                 ok | {error, _}.
-generate_source(ProtoFile) ->
-  generate_source(ProtoFile,[]).
-
-%%--------------------------------------------------------------------
-%% @doc Generats a source .erl file and header file .hrl
-%%      Consider option properties: output_include_dir,
-%%                                  output_src_dir,
-%%                                  imports_dir
-%%--------------------------------------------------------------------
--spec generate_source(ProtoFile :: string() | atom(), Options :: list()) ->
-                 ok | {error, _}.
-generate_source(ProtoFile,Options) when is_atom(ProtoFile) ->
-    generate_source(atom_to_list(ProtoFile) ++ ".proto", Options);
-generate_source(ProtoFile,Options) when is_list(ProtoFile) ->
+scan_file_src(ProtoFile) when is_list(ProtoFile) ->
     Basename = filename:basename(ProtoFile, ".proto") ++ "_pb",
-    {ok,String} = parse_file(ProtoFile),
-    {ok,FirstParsed} = parse_string(String),
-    ImportPaths = ["./", "src/" | proplists:get_value(imports_dir, Options, [])],
-    Parsed = parse_imports(FirstParsed, ImportPaths),
-    Collected = collect_full_messages(Parsed),
-    Messages = resolve_types(Collected#collected.msg,Collected#collected.enum),
-    output_source(Basename, Messages, Collected#collected.enum, Options).
+    Parsed = protobuffs_parser:parse_file(ProtoFile),
+    UntypedMessages = collect_full_messages(Parsed),
+    Messages = resolve_types (UntypedMessages),
+    output_src(Basename, Messages).
 
-%% @hidden
-parse_imports(Parsed, Path) ->
-    parse_imports(Parsed, Path, []).
+output_src(Basename, Messages) ->
+    ok = write_header_include_file(Basename, Messages),
+    BeamFile = filename:dirname(code:which(?MODULE)) ++ "/pokemon_pb.beam",
+	{ok,{_,[{abstract_code,{_,Forms}}]}} =beam_lib:chunks(BeamFile, [abstract_code]),
+    Forms1 = filter_forms(Messages, Forms, Basename, []),
+	SrcFile = Basename ++ ".erl",
+	file:write_file(SrcFile, erl_prettypr:format(erl_syntax:form_list(Forms1))).
 
-%% @hidden
-parse_imports([], _Path, Acc) ->
-    lists:reverse(Acc);
-parse_imports([{import, File} = Head | Tail], Path, Acc) ->
-    case protobuffs_file:path_open(Path, File, [read]) of
-    {ok, F, Fullname} ->
-        file:close(F),
-        {ok,String} = parse_file(Fullname),
-        {ok,FirstParsed} = parse_string(String),
-        Parsed = lists:append(FirstParsed, [file_boundary | Tail]),
-        parse_imports(Parsed, Path, [Head | Acc]);
-    {error, Error} ->
-        error_logger:error_report([
-                       "Could not do import",
-                       {import, File},
-                       {error, Error},
-                       {path, Path}
-                      ]),
-        parse_imports(Tail, Path, [Head | Acc])
-    end;
-parse_imports([Head | Tail], Path, Acc) ->
-    parse_imports(Tail, Path, [Head | Acc]).
+filter_forms(Msgs, [{attribute,L,file,{_,_}}|Tail], Basename, Acc) ->
+    filter_forms(Msgs, Tail, Basename, [{attribute,L,file,{"src/" ++ Basename ++ ".erl",L}}|Acc]);
 
-%% @hidden
-output(Basename, MessagesRaw, RawEnums, Options) ->
-    Messages = canonize_names(MessagesRaw),
-    Enums = canonize_names(RawEnums),
-    HeaderFile = case proplists:get_value(output_include_dir,Options) of
-    undefined ->
-        Basename ++ ".hrl";
-    HeaderPath ->
-        filename:join(HeaderPath,Basename) ++ ".hrl"
-    end,
+filter_forms(Msgs, [{attribute,L,module,pokemon_pb}|Tail], Basename, Acc) ->
+    filter_forms(Msgs, Tail, Basename, [{attribute,L,module,list_to_atom(Basename)}|Acc]);
 
-    error_logger:info_msg("Writing header file to ~p~n",[HeaderFile]),
-    ok = write_header_include_file(HeaderFile, Messages),
-    PokemonBeamFile = code:where_is_file("pokemon_pb.beam"),
-    {ok,{_,[{abstract_code,{_,Forms}}]}} = beam_lib:chunks(PokemonBeamFile, [abstract_code]),
-    Forms1 = filter_forms(Messages, Enums, Forms, Basename, []),
-    {ok, _, Bytes, _Warnings} = protobuffs_file:compile_forms(Forms1, proplists:get_value(compile_flags,Options,[])),
-    BeamFile = case proplists:get_value(output_ebin_dir,Options) of
-    undefined ->
-        Basename ++ ".beam";
-    BeamPath ->
-        filename:join(BeamPath,Basename) ++ ".beam"
-    end,
-    error_logger:info_msg("Writing beam file to ~p~n",[BeamFile]),
-    protobuffs_file:write_file(BeamFile, Bytes).
-
-%% @hidden
-output_source(Basename, MessagesRaw, Enums, Options) ->
-    Messages = canonize_names(MessagesRaw),
-    HeaderFile = case proplists:get_value(output_include_dir,Options) of
-    undefined ->
-        Basename ++ ".hrl";
-    HeaderPath ->
-        filename:join(HeaderPath,Basename) ++ ".hrl"
-    end,
-    error_logger:info_msg("Writing header file to ~p~n",[HeaderFile]),
-    ok = write_header_include_file(HeaderFile, Messages),
-    PokemonBeamFile = filename:dirname(code:which(?MODULE)) ++ "/pokemon_pb.beam",
-    {ok,{_,[{abstract_code,{_,Forms}}]}} = beam_lib:chunks(PokemonBeamFile, [abstract_code]),
-    Forms1 = filter_forms(Messages, Enums, Forms, Basename, []),
-    SrcFile = case proplists:get_value(output_src_dir,Options) of
-    undefined ->
-        Basename ++ ".erl";
-    SrcPath ->
-        filename:join(SrcPath,Basename) ++ ".erl"
-    end,
-    error_logger:info_msg("Writing src file to ~p~n",[SrcFile]),
-    protobuffs_file:write_file(SrcFile, erl_prettypr:format(erl_syntax:form_list(Forms1))).
-
-%% @hidden
-parse_file(FileName) ->
-    {ok, InFile} = protobuffs_file:open(FileName, [read]),
-    String = parse_file(InFile,[]),
-    file:close(InFile),
-    {ok,String}.
-
-%% @hidden
-parse_file(InFile,Acc) ->
-    case protobuffs_file:request(InFile) of
-        {ok,Token,_EndLine} ->
-            parse_file(InFile,Acc ++ [Token]);
-        {error,token} ->
-            exit(scanning_error);
-        {eof,_} ->
-            Acc
-    end.
-
-parse_string(String) ->
-    case lists:all(fun erlang:is_integer/1, String) of
-        true ->
-            {ok, Tokens, _Line} = protobuffs_scanner:string(String),
-            protobuffs_parser:parse(Tokens);
-        false ->
-            protobuffs_parser:parse(String)
-    end.
-
-%% @hidden
-filter_forms(Msgs, Enums, [{attribute,L,file,{_,_}}|Tail], Basename, Acc) ->
-    filter_forms(Msgs, Enums, Tail, Basename, [{attribute,L,file,{"src/" ++ Basename ++ ".erl",L}}|Acc]);
-
-filter_forms(Msgs, Enums, [{attribute,L,module,pokemon_pb}|Tail], Basename, Acc) ->
-    filter_forms(Msgs, Enums, Tail, Basename, [{attribute,L,module,list_to_atom(Basename)}|Acc]);
-
-filter_forms(Msgs, Enums, [{attribute,L,export,[{encode_pikachu,1},{decode_pikachu,1},{delimited_decode_pikachu,1}]}|Tail], Basename, Acc) ->
+filter_forms(Msgs, [{attribute,L,export,[{encode_pikachu,1},{decode_pikachu,1},{encode,1},{decode,2}]}|Tail], Basename, Acc) ->
     Exports = lists:foldl(
-        fun({Name,_,_}, Acc1) ->
+        fun({Name,_}, Acc1) ->
             [{list_to_atom("encode_" ++ string:to_lower(Name)),1},
-             {list_to_atom("decode_" ++ string:to_lower(Name)),1},
-             {list_to_atom("delimited_decode_" ++ string:to_lower(Name)),1} | Acc1]
+             {list_to_atom("decode_" ++ string:to_lower(Name)),1} | Acc1]
         end, [], Msgs),
-    filter_forms(Msgs, Enums, Tail, Basename, [{attribute,L,export,Exports}|Acc]);
+    Exports1 = [{encode,1},{encode,2},{decode,2}] ++ Exports,
+    filter_forms(Msgs, Tail, Basename, [{attribute,L,export,Exports1}|Acc]);
 
-filter_forms(Msgs, Enums, [{attribute,L,record,{pikachu,_}}|Tail], Basename, Acc) ->
+filter_forms(Msgs, [{attribute,L,record,{pikachu,_}}|Tail], Basename, Acc) ->
     Records = [begin
-           OutFields = [string:to_lower(A) || {_, _, _, A, _} <- lists:keysort(1, Fields)],
-       ExtendField = case Extends of
-           disallowed -> [];
-           _ -> [{record_field,L,{atom,L,'$extensions'}}]
-       end,
-           Frm_Fields = [{record_field,L,{atom,L,list_to_atom(OutField)}}|| OutField <- OutFields] ++ ExtendField,
-           {attribute, L, record, {atomize(Name), Frm_Fields}}
-           end || {Name, Fields,Extends} <- Msgs],
-    filter_forms(Msgs, Enums, Tail, Basename, Records ++ Acc);
+        OutFields = [string:to_lower(A) || {_, _, _, A, _, _} <- lists:keysort(1, Fields)],
+        Frm_Fields = [{record_field,L,{atom,L,list_to_atom(OutField)}}|| OutField <- OutFields],
+        {attribute, L, record, {atomize(Name), Frm_Fields}}
+     end || {Name, Fields} <- Msgs],
+    filter_forms(Msgs, Tail, Basename, Records ++ Acc);
 
-filter_forms(Msgs, Enums, [{function,L,encode_pikachu,1,[ListClause, RecordClause]}|Tail], Basename, Acc) ->
+filter_forms(Msgs, [{function,L,encode_pikachu,1,[Clause]}|Tail], Basename, Acc) ->
     Functions = [begin
-             {function,L,list_to_atom("encode_" ++ string:to_lower(Name)),1,[replace_atom(ListClause, pikachu, atomize(Name)), replace_atom(RecordClause, pikachu, atomize(Name))]}
-         end || {Name, _, _} <- Msgs],
-    filter_forms(Msgs, Enums, Tail, Basename, Functions ++ Acc);
+        {function,L,list_to_atom("encode_" ++ string:to_lower(Name)),1,[replace_atom(Clause, pikachu, atomize(Name))]} 
+    end || {Name, _} <- Msgs],
+    filter_forms(Msgs, Tail, Basename, Functions ++ Acc);
 
-filter_forms(Msgs, Enums, [{function,L,encode,2,[ListClause, RecordClause]}|Tail], Basename, Acc) ->
-    filter_forms(Msgs, Enums, Tail, Basename, [expand_encode_function(Msgs, L, ListClause, RecordClause)|Acc]);
+filter_forms(Msgs, [{function,L,encode,2,[Clause]}|Tail], Basename, Acc) ->
+    filter_forms(Msgs, Tail, Basename, [expand_encode_function(Msgs, L, Clause)|Acc]);
 
-filter_forms(Msgs, Enums, [{function,L,encode_extensions,1,[EncodeClause,Catchall]}|Tail], Basename, Acc) ->
-    NewEncodeClauses = [replace_atom(EncodeClause, pikachu, atomize(Name)) ||
-        {Name, _Fields, Extens} <- Msgs, Extens =/= disallowed],
-    NewClauses = NewEncodeClauses ++ [Catchall],
-    NewFunction = {function,L,encode_extensions,1,NewClauses},
-    filter_forms(Msgs, Enums, Tail, Basename, [NewFunction | Acc]);
-
-filter_forms(Msgs, Enums, [{function,L,iolist,2,[Clause]}|Tail], Basename, Acc) ->
-     filter_forms(Msgs, Enums, Tail, Basename, [expand_iolist_function(Msgs, L, Clause)|Acc]);
-
-filter_forms(Msgs, Enums, [{function,L,decode_pikachu,1,[Clause]}|Tail], Basename, Acc) ->
+filter_forms(Msgs, [{function,L,decode_pikachu,1,[Clause]}|Tail], Basename, Acc) ->
     Functions = [begin
-             {function,
-              L,
-              list_to_atom("decode_" ++ string:to_lower(Name)),
-              1,
-              [replace_atom(Clause, pikachu, atomize(Name))]}
-         end || {Name, _, _} <- Msgs],
-    filter_forms(Msgs, Enums, Tail, Basename, Functions ++ Acc);
+        {function,L,list_to_atom("decode_" ++ string:to_lower(Name)),1,[replace_atom(Clause, pikachu, atomize(Name))]} 
+    end || {Name, _} <- Msgs],
+    filter_forms(Msgs, Tail, Basename, Functions ++ Acc);
 
-filter_forms(Msgs, Enums, [{function,L,delimited_decode_pikachu,1,[Clause]} | Tail], Basename, Acc) ->
-    Acc2 = lists:foldl(fun({Name, _, _}, Acc1) ->
-        Clause2 = replace_atom(Clause, pikachu, atomize(Name)),
-        Function = {function,L,list_to_atom("delimited_decode_" ++ string:to_lower(Name)),1,[Clause2]},
-        [Function | Acc1]
-    end, Acc, Msgs),
-    filter_forms(Msgs, Enums, Tail, Basename, Acc2);
+filter_forms(Msgs, [{function,L,decode,2,[Clause]}|Tail], Basename, Acc) ->
+    filter_forms(Msgs, Tail, Basename, [expand_decode_function(Msgs, L, Clause)|Acc]);
 
-filter_forms(Msgs, Enums, [{function,L,decode,2,[Clause]}|Tail], Basename, Acc) ->
-    filter_forms(Msgs, Enums, Tail, Basename, [expand_decode_function(Msgs, L, Clause)|Acc]);
+filter_forms(Msgs, [{function,L,to_record,2,[Clause]}|Tail], Basename, Acc) ->
+    filter_forms(Msgs, Tail, Basename, [expand_to_record_function(Msgs, L, Clause)|Acc]);
 
-filter_forms(Msgs, Enums, [{function,L,to_record,2,[Clause]}|Tail], Basename, Acc) ->
-    filter_forms(Msgs, Enums, Tail, Basename, [expand_to_record_function(Msgs, L, Clause)|Acc]);
+filter_forms(Msgs, [Form|Tail], Basename, Acc) ->
+    filter_forms(Msgs, Tail, Basename, [Form|Acc]);
 
-filter_forms(Msgs, Enums, [{function,L,enum_to_int,2,[Clause]}|Tail], Basename, Acc) ->
-    filter_forms(Msgs, Enums, Tail, Basename, [expand_enum_to_int_function(Enums, L, Clause)|Acc]);
+filter_forms(_, [], _, Acc) -> lists:reverse(Acc).
 
-filter_forms(Msgs, Enums, [{function,L,int_to_enum,2,[Clause]}|Tail], Basename, Acc) ->
-    filter_forms(Msgs, Enums, Tail, Basename, [expand_int_to_enum_function(Enums, L, Clause)|Acc]);
+expand_encode_function(Msgs, Line, Clause) ->
+    {function,Line,encode,2,[filter_encode_clause(Msg, Clause) || Msg <- Msgs]}.
 
-filter_forms(Msgs, Enums, [{function,L,decode_extensions,1,[Clause,Catchall]}|Tail],Basename, Acc) ->
-    NewClauses = filter_decode_extensions_clause(Msgs, Msgs, Clause, []),
-    NewHead = {function,L,decode_extensions,1,NewClauses ++ [Catchall]},
-    filter_forms(Msgs, Enums, Tail,Basename,[NewHead|Acc]);
-
-filter_forms(Msgs, Enums, [{function,L,extension_size,1,[RecClause,CatchAll]}|Tail],Basename, Acc) ->
-    NewRecClauses = filter_extension_size(Msgs, RecClause, []),
-    NewClauses = lists:reverse([CatchAll | NewRecClauses]),
-    NewHead = {function,L,extension_size,1,NewClauses},
-    filter_forms(Msgs, Enums, Tail, Basename, [NewHead|Acc]);
-
-filter_forms(Msgs, Enums, [{function,L,has_extension,2,[FilterClause,CatchallClause]}|Tail],Basename,Acc) ->
-    NewRecClauses = filter_has_extension(Msgs, FilterClause, []),
-    NewClauses = lists:reverse([CatchallClause | NewRecClauses]),
-    NewHead = {function,L,has_extension,2,NewClauses},
-    filter_forms(Msgs, Enums, Tail, Basename, [NewHead | Acc]);
-
-filter_forms(Msgs, Enums, [{function,L,get_extension,2,[AtomClause,IntClause,Catchall]}|Tail],Basename,Acc) ->
-    NewAtomClauses = filter_get_extension_atom(Msgs,AtomClause,[]),
-    NewRecClauses = filter_get_extension_integer(Msgs, IntClause, NewAtomClauses),
-    NewClauses = lists:reverse([Catchall | NewRecClauses]),
-    NewHead = {function,L,get_extension,2,NewClauses},
-    filter_forms(Msgs,Enums, Tail, Basename, [NewHead | Acc]);
-
-filter_forms(Msgs, Enums, [{function,L,set_extension,3,[RecClause,Catchall]}|Tail],Basename, Acc) ->
-    NewRecClauses = filter_set_extension(Msgs, RecClause, []),
-    NewClauses = lists:reverse([Catchall | NewRecClauses]),
-    NewHead = {function,L,set_extension,3,NewClauses},
-    filter_forms(Msgs,Enums,Tail,Basename,[NewHead|Acc]);
-
-filter_forms(Msgs, Enums, [{function,_L,with_default,2,_Args}=Func|Tail],Basename,Acc) ->
-    Acc2 = case any_message_has_fields(Msgs) of
-        true -> [Func|Acc];
-        false -> Acc
-    end,
-    filter_forms(Msgs,Enums,Tail,Basename,Acc2);
-
-filter_forms(Msgs, Enums, [{function,_L,pack,5,_Clauses}=Func|Tail],Basename,Acc) ->
-    Acc2 = case any_message_has_fields(Msgs) orelse any_message_has_extentions(Msgs) of
-        true -> [Func|Acc];
-        false -> Acc
-    end,
-    filter_forms(Msgs,Enums,Tail,Basename,Acc2);
-
-filter_forms(Msgs, Enums, [Form|Tail], Basename, Acc) ->
-    filter_forms(Msgs, Enums, Tail, Basename, [Form|Acc]);
-
-filter_forms(_, _, [], _, Acc) -> lists:reverse(Acc).
-
-any_message_has_extentions(Msgs) ->
-    Predicate = fun({_,_,disallowed}) -> false; (_) -> true end,
-    lists:any(Predicate, Msgs).
-
-any_message_has_fields(Msgs) ->
-    Predicate = fun({_,[],_}) -> false; (_) -> true end,
-    lists:any(Predicate, Msgs).
-
-%% @hidden
-filter_set_extension([],_,Acc) ->
-    Acc;
-filter_set_extension([{_,_,disallowed}|Tail],Clause,Acc) ->
-    filter_set_extension(Tail,Clause,Acc);
-filter_set_extension([{MsgName,_,Extends}|Tail],Clause,Acc) ->
-    {clause,L,[OldRecArg,_OldAtomArg,ValueArg],Gs,[OldSet,OldReturn]} = Clause,
-    {match,L,{record,L,_,RecArgFields},RecVar} = OldRecArg,
-    {match,L2,NewReturn,OldDictStore} = OldSet,
-    {call,L2,DictStore,[_StoreKey,_StoreVal,StoreVar]} = OldDictStore,
-    {tuple,L3,[Ok, OldReturnRec]} = OldReturn,
-    {record,L3,ReturnRecVar,_OldName,Fields} = OldReturnRec,
-    Folder = fun({Id, Rule, StrType, Name, Opts}, Facc) ->
-        Type = atomize(StrType),
-        FClause = {clause,L,[{match,L,{record,L,atomize(MsgName),RecArgFields},RecVar},{atom,L,atomize(Name)},ValueArg],Gs,[
-            {match,L2,NewReturn,{call,L2,DictStore,[{integer,L2,Id},{tuple,L2,[erl_parse:abstract(Rule),ValueArg,erl_parse:abstract(Type),erl_parse:abstract(Opts)]},StoreVar]}},
-            {tuple,L3,[Ok,{record,L3,ReturnRecVar,atomize(MsgName),Fields}]}
-        ]},
-        [FClause | Facc]
-    end,
-    NewAcc = lists:foldl(Folder, Acc, Extends),
-    filter_set_extension(Tail,Clause,NewAcc).
-
-%% @hidden
-filter_get_extension_atom([],_AtomClause,Acc) ->
-    Acc;
-filter_get_extension_atom([{_,_,disallowed}|Tail],Clause,Acc) ->
-    filter_get_extension_atom(Tail,Clause,Acc);
-filter_get_extension_atom([{Msg,_,Extends}|Tail],Clause,Acc) ->
-    {clause,L,[RecArg,_OldAtom],[RecG],[OldSubcall]} = Clause,
-    [{call,L,Guard,[Garg1,_RecName]}] = RecG,
-    {call,L1,Subname,[RecVar,_OldInt]} = OldSubcall,
-    NewG = [{call,L,Guard,[Garg1,{atom,L,atomize(Msg)}]}],
-    NewClauses = [
-        {clause,L,[RecArg,{atom,L,atomize(FName)}],[NewG],[
-          {call,L1,Subname,[RecVar,{integer,L1,FId}]}
-        ]} ||
-      {FId, _, _, FName, _} <- Extends],
-    NewAcc = lists:append(NewClauses,Acc),
-    filter_get_extension_atom(Tail,Clause,NewAcc).
-
-%% @hidden
-filter_get_extension_integer([],_,Acc) ->
-    Acc;
-filter_get_extension_integer([{_,_,disallowed}|Tail],IntClause,Acc) ->
-    filter_get_extension_integer(Tail,IntClause,Acc);
-filter_get_extension_integer([{Msg,_,_Extends}|Tail],IntClause,Acc) ->
-    {clause,L,[{record,L,Pikachu,Fields},IntArg],Gs,Body} = IntClause,
-    NewRecName = replace_atom(Pikachu, pikachu, atomize(Msg)),
-    NewRecArg = {record,L,NewRecName,Fields},
-    NewClause = {clause,L,[NewRecArg,IntArg],Gs,Body},
-    NewAcc = [NewClause|Acc],
-    filter_get_extension_integer(Tail,IntClause,NewAcc).
-
-%% @hidden
-filter_has_extension([], _, Acc) ->
-    % non-reverseal is intentional.
-    Acc;
-filter_has_extension([{_Msg,_,disallowed}|Tail], Clause, Acc) ->
-    filter_has_extension(Tail, Clause, Acc);
-filter_has_extension([{MsgName,_,Extends}|Tail], Clause, Acc) ->
-    {clause,L,[OldRecArg,_],G,[Body]} = Clause,
-        {call, L1, {remote,L1,Dict,IsKey},[_Key,DictArg]} = Body,
-    RecArg = replace_atom(OldRecArg,pikachu,atomize(MsgName)),
-    Folder = fun({ID, _Rules, _Type, Name, _Other}, FoldAcc) ->
-        AtomClause = {clause,L,[RecArg,{atom,L,atomize(Name)}],G,[
-            {call,L,{remote,L,Dict,IsKey},[{atom,L,atomize(Name)},DictArg]}
-        ]},
-        IntClause = {clause,L,[RecArg,{integer,L,ID}],G,[
-            {call,L,{remote,L,Dict,IsKey},[{integer,L,ID},DictArg]}
-        ]},
-        [AtomClause,IntClause|FoldAcc]
-    end,
-    NewClauses = lists:foldl(Folder, [], Extends),
-    NewAcc = lists:append(Acc,NewClauses),
-    filter_has_extension(Tail,Clause,NewAcc).
-
-%% @hidden
-filter_extension_size([], _RecClause, Acc) ->
-    % the non-reversal is intentional.
-    Acc;
-filter_extension_size([{_MsgName,_,disallowed}|Tail],Clause,Acc) ->
-    filter_extension_size(Tail,Clause,Acc);
-filter_extension_size([{MsgName,_,_}|Tail],Clause,Acc) ->
-    {clause,L,[OldArg],G,Body} = Clause,
-    NewClause = {clause,L,[replace_atom(OldArg,pikachu,atomize(MsgName))],G,Body},
-    NewAcc = [NewClause | Acc],
-    filter_extension_size(Tail,Clause,NewAcc).
-
-%% @hidden
-filter_delimited_encode_clause({MsgName, _Fields, _Extends}, {clause,L,[_PlaceholderName | Args],Guards,Content}) ->
-    {clause,L,[{atom,L,atomize(MsgName)}|Args], Guards, Content}.
-
-%% @hidden
-filter_record_encode_clause({MsgName, _Fields,_Extends}, {clause,L,_Args,Guards,_Content}) ->
-    ToIolist = {cons, L,
-                {call,L, {atom,L,iolist}, [{atom,L,atomize(MsgName)},{var,L,'Record'}]},
-                {call,L, {atom,L,encode_extensions}, [{var,L,'Record'}]}
-               },
-    {clause,L,[{atom,L,atomize(MsgName)},{var,L,'Record'}],Guards,[ToIolist]}.
-
-expand_iolist_function(Msgs, Line, Clause) ->
-    {function,Line,iolist,2,[filter_iolist_clause(Msg, Clause) || Msg <- Msgs]}.
-
-filter_iolist_clause({MsgName, [], _Extends0}, {clause,L,_Args,Guards,_Content}) ->
-    {clause,L,[{atom,L,atomize(MsgName)},{var,L,'_Record'}],Guards,[{nil,L}]};
-filter_iolist_clause({MsgName, Fields0, _Extends0}, {clause,L,_Args,Guards,_Content}) ->
-    Fields = [
-        case Tag of
-        optional ->
-            Field;
-        _ ->
-            {FNum,Tag,SType,SName,none}
-        end
-        || {FNum,Tag,SType,SName,_} = Field <- Fields0 ],
+filter_encode_clause({MsgName, Fields}, {clause,L,_Args,Guards,_Content}) ->
     Cons = lists:foldl(
-         fun({FNum,Tag,SType,SName,Default}, Acc) ->
-             {cons,L,
-              {call,L,{atom,L,pack},[{integer,L,FNum},
-                         {atom,L,Tag},
-                         {call,L,
-                          {atom,L,with_default},
-                          [{record_field,L,
-                        {var,L,'Record'},atomize(MsgName),
-                        {atom,L,atomize(SName)}},
-                           erl_parse:abstract(Default)]},
-                         {atom,L,atomize(SType)},
-                         {nil,L}]},
-              Acc}
-         end, {nil,L}, lists:reverse(lists:keysort(1, Fields))),
-    {clause,L,[{atom,L,atomize(MsgName)},{var,L,'Record'}],Guards,[Cons]}.
+        fun({FNum,Tag,SType,SName,_,Default}, Acc) ->
+            {cons,L,
+                {call,L,{atom,L,pack},[
+                    {integer,L,FNum},
+                    {atom,L,Tag},
+                    {call,L,{atom,L,with_default},[{record_field,L,{var,L,'_Record'},atomize(MsgName),{atom,L,atomize(SName)}},erl_parse:abstract(Default)]},
+                    {atom,L,atomize(SType)},
+                    {nil,L}]},
+                Acc}
+        end, {nil,L}, Fields),
+    ToBin = {call,L,{atom,L,iolist_to_binary},[Cons]},
+    {clause,L,[{atom,L,atomize(MsgName)},{var,L,'_Record'}],Guards,[ToBin]}.
 
-%% @hidden
 expand_decode_function(Msgs, Line, Clause) ->
-    {function,Line,decode,2, [{clause,Line,[{atom,Line,enummsg_values},{integer,Line,1}],[],[{atom,Line,value1}]}] ++
-     [filter_decode_clause(Msgs, Msg, Clause) || Msg <- Msgs]}.
+    {function,Line,decode,2,[filter_decode_clause(Msgs, Msg, Clause) || Msg <- Msgs]}.
 
-%% @hidden
-filter_decode_clause(Msgs, {MsgName, Fields, Extends}, {clause,L,_Args,Guards,[_,_,C,D]}) ->
-    Types = lists:keysort(1, [begin
-            {FNum, list_to_atom(SName),
-                   atomize(SType),
-                   decode_opts(Msgs, Tag, SType), Def} end ||
-                 {FNum,Tag,SType,SName,Def} <- Fields]),
+filter_decode_clause(Msgs, {MsgName, Fields}, {clause,L,_Args,Guards,[_,B,C]}) ->
+    Types = lists:keysort(1, [{FNum, atomize(SName), atomize(SType), decode_opts(Msgs, Tag, SType)} || {FNum,Tag,SType,SName,_,_} <- Fields]),
     Cons = lists:foldl(
-         fun({FNum, FName, Type, Opts, _Def}, Acc) ->
-             {cons,L,{tuple,L,[{integer,L,FNum},{atom,L,list_to_atom(string:to_lower(atom_to_list(FName)))},{atom,L,Type},erl_parse:abstract(Opts)]},Acc}
-         end, {nil,L}, Types),
-    ExtendDefault = case Extends of
-        disallowed -> {nil,L};
-        _ -> erl_parse:abstract([{false, '$extensions', dict:new()}])
-    end,
-    Defaults = lists:foldr(
-        fun
-            ({_FNum, _FName, _Type, _Opts, none}, Acc) ->
-                Acc;
-            ({FNum, FName, _Type, _Opts, Def}, Acc) ->
-                {cons,L,{tuple,L,[{integer,L,FNum},{atom,L,list_to_atom(string:to_lower(atom_to_list(FName)))},erl_parse:abstract(Def)]},Acc}
-        end,
-        ExtendDefault,
-        Types),
+        fun({FNum, FName, Type, Opts}, Acc) ->
+            {cons,L,{tuple,L,[{integer,L,FNum},{atom,L,FName},{atom,L,Type},erl_parse:abstract(Opts)]},Acc}
+        end, {nil,L}, Types),
     A = {match,L,{var,L,'Types'},Cons},
-    B = {match,L,{var,L,'Defaults'},Defaults},
-    D1 = replace_atom(D, pikachu, atomize(MsgName)),
-    {clause,L,[{atom,L,atomize(MsgName)},{var,L,'Bytes'}],Guards,[A,B,C,D1]}.
+    C1 = replace_atom(C, pikachu, atomize(MsgName)),
+    {clause,L,[{atom,L,atomize(MsgName)},{var,L,'Bytes'}],Guards,[A,B,C1]}.
 
-%% @hidden
-filter_decode_extensions_clause(_,[],_,Acc) ->
-    lists:reverse(Acc);
-filter_decode_extensions_clause(Msgs,[{_,_,disallowed}|Tail],Clause,Acc) ->
-    filter_decode_extensions_clause(Msgs,Tail,Clause,Acc);
-filter_decode_extensions_clause(Msgs,[{MsgName,_,Extends}|Tail],Clause,Acc) ->
-    {clause,L,_,_,_} = Clause,
-    Types = lists:keysort(1, [{FNum, list_to_atom(SName),
-                   atomize(SType),
-                   decode_opts(Msgs, Tag, SType), Def} ||
-                 {FNum,Tag,SType,SName,Def} <- Extends]),
-    Cons = lists:foldl(
-         fun({FNum, FName, Type, Opts, _Def}, AccF) ->
-             {cons,L,{tuple,L,[{integer,L,FNum},{atom,L,FName},{atom,L,Type},erl_parse:abstract(Opts)]},AccF}
-         end, {nil,L}, Types),
-    A = {match,L,{var,L,'Types'},Cons},
-        {clause,L,[Arg],Guards,[_,B,C]} = Clause,
-        NewBody = [A,B,replace_atom(C,pikachu,atomize(MsgName))],
-        NewClause = {clause,L,[replace_atom(Arg, pikachu, atomize(MsgName))],Guards,NewBody},
-    filter_decode_extensions_clause(Msgs,Tail,Clause,[NewClause|Acc]).
-
-%% @hidden
-expand_encode_function(Msgs, Line, ListClause, RecordClause) ->
-    Clauses = lists:foldl(fun(Msg, Acc) ->
-        DelimClause = filter_delimited_encode_clause(Msg, ListClause),
-        RecClause = filter_record_encode_clause(Msg, RecordClause),
-        Acc ++ [DelimClause, RecClause]
-    end, [], Msgs),
-    {function,Line,encode,2,Clauses}.
-
-%% @hidden
 decode_opts(Msgs, Tag, Type) ->
-    Opts0 = if Tag == repeated -> [repeated]; Tag == repeated_packed -> [repeated_packed]; true -> [] end,
+    Opts0 = if Tag == repeated -> [repeated]; true -> [] end,
     case lists:keymember(Type, 1, Msgs) of
         true ->
             [is_record|Opts0];
@@ -544,399 +147,148 @@ decode_opts(Msgs, Tag, Type) ->
             Opts0
     end.
 
-%% @hidden
 expand_to_record_function(Msgs, Line, Clause) ->
     {function,Line,to_record,2,[filter_to_record_clause(Msg, Clause) || Msg <- Msgs]}.
 
-%% @hidden
-filter_to_record_clause({MsgName, _, Extends}, {clause,L,[_Param1,Param2],Guards,[Fold,_DecodeExtends]}) ->
+filter_to_record_clause({MsgName, _}, {clause,L,[_Param1,Param2],Guards,[Fold]}) ->
     Fold1 = replace_atom(Fold, pikachu, atomize(MsgName)),
-    ReturnLine = case Extends of
-        disallowed ->
-            {var,L,'Record1'};
-        _ ->
-            {ok, Tokens, _} = erl_scan:string("decode_extensions(Record1)."),
-              {ok, [Abstract]} = erl_parse:parse_exprs(Tokens),
-            Abstract
-    end,
-    {clause,L,[{atom,L,atomize(MsgName)},Param2],Guards,[Fold1,ReturnLine]}.
+    {clause,L,[{atom,L,atomize(MsgName)},Param2],Guards,[Fold1]}.
 
-%% @hidden
-expand_enum_to_int_function([], Line, Clause) ->
-    {function,Line,enum_to_int,2,[Clause]};
-expand_enum_to_int_function(Enums, Line, Clause) ->
-    {function,Line,enum_to_int,2,[filter_enum_to_int_clause(Enum, Clause) || Enum <- Enums]}.
-
-%% @hidden
-filter_enum_to_int_clause({enum,EnumTypeName,IntValue,EnumValue}, {clause,L,_Args,Guards,_}) ->
-    {clause,L,[{atom,L,atomize(EnumTypeName)},{atom,L,EnumValue}],Guards,[{integer,L,IntValue}]}.
-
-%% @hidden
-expand_int_to_enum_function([], Line, Clause) ->
-    {function,Line,int_to_enum,2,[Clause]};
-expand_int_to_enum_function(Enums, Line, Clause) ->
-    {function,Line,int_to_enum,2, [filter_int_to_enum_clause(Enum, Clause) || Enum <- Enums] ++ [Clause]}.
-
-%% @hidden
-filter_int_to_enum_clause({enum,EnumTypeName,IntValue,EnumValue}, {clause,L,_Args,Guards,_}) ->
-    {clause,L,[{atom,L,atomize(EnumTypeName)},{integer,L,IntValue}],Guards,[{atom,L,EnumValue}]}.
-
-%% @hidden
 %% [{"Location",
-%%   [{2,required,"string","country",none},
-%%    {1,required,"string","region",none}]},
+%%   [{2,required,"string","country",number,none},
+%%    {1,required,"string","region",number,none}]},
 %%  {"Person",
-%%   [{5,optional,"Location","location",none},
-%%    {4,required,"int32","age",none},
-%%    {3,required,"string","phone_number",none},
-%%    {2,required,"string","address",none},
-%%    {1,required,"string","name",none}]}]
-collect_full_messages(Data) -> collect_full_messages(Data, #collected{}).
-collect_full_messages([{message, Name, Fields} | Tail], Collected) ->
-    Package = Collected#collected.package,
-    ListName = resolve_list_name(Name, Package),
+%%   [{5,optional,"Location","location",number,none},
+%%    {4,required,"int32","age",number,none},
+%%    {3,required,"string","phone_number",number,none},
+%%    {2,required,"string","address",number,none},
+%%    {1,required,"string","name",number,none}]}]
+collect_full_messages(Data) -> collect_full_messages(Data, []).
+collect_full_messages([{message, Name, Fields} | Tail], Acc) ->
+  ListName = case erlang:is_list (hd(Name)) of
+               true -> Name;
+               false -> [Name]
+             end,
 
-    FieldsOut = lists:foldl(
-          fun ({_,_,_,_,_} = Input, TmpAcc) -> [Input | TmpAcc];
-              (_, TmpAcc) -> TmpAcc
-          end, [], Fields),
+  FieldsOut = lists:foldl(
+    fun (Input, TmpAcc) ->
+        case Input of
+          {_, _, _, _, _, _} ->  [Input | TmpAcc];
+          _ -> TmpAcc
+        end
+    end, [], Fields),
 
-    Enums = lists:foldl(
-          fun ({enum,C,D}, TmpAcc) -> [{enum, [list_to_tuple([C | LN]) || LN <- ListName], D} | TmpAcc];
-          (_, TmpAcc) -> TmpAcc
-          end, [], Fields),
+  SubMessages = lists:foldl(
+    fun ({message, C, D}, TmpAcc) -> [{message, [C | ListName], D} | TmpAcc];
+      (_, TmpAcc) -> TmpAcc
+    end, [], Fields),
 
-    Extensions = lists:foldl(
-           fun ({extensions, From, To}, TmpAcc) -> [{From,To}|TmpAcc];
-               (_, TmpAcc) -> TmpAcc
-           end, [], Fields),
-
-    SubMessages = lists:foldl(
-            fun ({message, C, D}, TmpAcc) -> [{message, [list_to_tuple([C | LN]) || LN <- ListName], D} | TmpAcc];
-            (_, TmpAcc) -> TmpAcc
-            end, [], Fields),
-
-    ExtendedFields = case Extensions of
-        [] -> disallowed;
-        _ -> []
-    end,
-
-    NewCollected = Collected#collected{
-             msg=[{[list_to_tuple(L) || L <- ListName], FieldsOut, ExtendedFields} | Collected#collected.msg],
-             extensions=[{[list_to_tuple(L) || L <- ListName],Extensions} | Collected#collected.extensions]
-            },
-    collect_full_messages(Tail ++ SubMessages ++ Enums, NewCollected);
-collect_full_messages([{enum, Name, Fields} | Tail], Collected) ->
-    Package = Collected#collected.package,
-    ListName = resolve_list_name(Name, Package),
-
-    FieldsOut = lists:foldl(
-          fun (Field, TmpAcc) ->
-              case Field of
-                  {EnumAtom, IntValue} -> [{enum,
-                            [type_path_to_type(LN) || LN <-ListName],
-                            IntValue,
-                            EnumAtom} | TmpAcc];
-                  _ -> TmpAcc
-              end
-          end, [], Fields),
-
-    NewCollected = Collected#collected{enum=FieldsOut++Collected#collected.enum},
-    collect_full_messages(Tail, NewCollected);
-collect_full_messages([{syntax,_} | Tail], Collected) ->
-    collect_full_messages(Tail, Collected);
-collect_full_messages([{package, PackageName} | Tail], Collected) ->
-    collect_full_messages(Tail, Collected#collected{package = PackageName});
-collect_full_messages([{option,_,_} | Tail], Collected) ->
-    collect_full_messages(Tail, Collected);
-collect_full_messages([{import, _Filename} | Tail], Collected) ->
-    collect_full_messages(Tail, Collected);
-collect_full_messages([{extend, Name, ExtendedFields} | Tail], Collected) ->
-    SeekName0 = string:tokens(Name, "."),
-    SeekName1 = [list_to_tuple(lists:reverse(SeekName0))],
-    SeekNames0 = resolve_list_name(SeekName1, Collected#collected.package),
-    SeekNames = [list_to_tuple(SN) || SN <- SeekNames0],
-
-    #collected{msg = CollectedMsg} = Collected,
-    BestMatch = element(1, find_message_by_path(SeekNames, CollectedMsg)),
-
-    {ListName,FieldsOut,ExtendFields} = lists:keyfind(BestMatch,1,CollectedMsg),
-    {ListName,Extensions} = lists:keyfind(BestMatch,1,Collected#collected.extensions),
-
-    FunNotInReservedRange = fun(Id) -> not(19000 =< Id andalso Id =< 19999) end,
-    FunInRange = fun(Id,From,max) -> From =< Id andalso Id =< 16#1fffffff;
-            (Id,From,To) -> From =< Id andalso Id =< To
-         end,
-
-    ExtendedFieldsOut = lists:append(FieldsOut,
-                 lists:foldl(
-                   fun ({Id, _, _, FieldName, _} = Input, TmpAcc) ->
-                       case lists:any(fun({From,To}) -> FunNotInReservedRange(Id)
-                                        andalso FunInRange(Id,From,To)
-                              end,Extensions) of
-                       true ->
-                           [Input | TmpAcc];
-                       _ ->
-                           error_logger:error_report(["Extended field not in valid range",
-                                      {message, Name},
-                                      {field_id,Id},
-                                      {field_name,FieldName},
-                                      {defined_ranges,Extensions},
-                                      {reserved_range,{19000,19999}},
-                                      {max,16#1fffffff}]),
-                           throw(out_of_range)
-                       end;
-                   (_, TmpAcc) -> TmpAcc
-                   end, [], ExtendedFields)
-                 ),
-    NewExtends = case ExtendFields of
-        disallowed -> disallowed;
-        _ -> ExtendFields ++ ExtendedFieldsOut
-    end,
-    NewCollected = Collected#collected{msg=lists:keyreplace(ListName,1,CollectedMsg,{ListName,FieldsOut,NewExtends})},
-    collect_full_messages(Tail, NewCollected);
-collect_full_messages([file_boundary | Tail], Collected) ->
-    collect_full_messages(Tail, Collected#collected{package = undefined});
-%% Skip anything we don't understand
-collect_full_messages([Skip|Tail], Acc) ->
-    error_logger:warning_report(["Unkown, skipping",
-                 {skip,Skip}]),
+  collect_full_messages(Tail ++ SubMessages, [{ListName, FieldsOut} | Acc]);
+collect_full_messages([{package, _Line1},
+                       {bareword, _Line2, _PackageName},
+                       {';', _Line3} | Tail], Acc) ->
     collect_full_messages(Tail, Acc);
-collect_full_messages([], Collected) ->
-    Collected.
-
-%% @hidden
-find_message_by_path(_TypeName, []) ->
-    false;
-find_message_by_path(TypeName, [Msg | Tail]) ->
-    Names = element(1, Msg),
-    case [N || N <- Names, lists:member(N, TypeName)] of
-        [] ->
-            find_message_by_path(TypeName, Tail);
-        _ ->
-            Msg
-    end.
-
-%% @hidden
-resolve_list_name(Name, _Package) when is_tuple(hd(Name)) ->
-    [tuple_to_list(N) || N <- Name];
-resolve_list_name(Name, undefined) when is_integer(hd(Name)) ->
-    [[Name]];
-resolve_list_name(Name, Package) when is_integer(hd(Name)) ->
-    [[Name], [Name, Package]].
-
-%% @hidden
-resolve_types(Data, Enums) -> resolve_types (Data, Data, Enums, []).
-resolve_types([{TypePath, Fields,Extended} | Tail], AllPaths, Enums, Acc) ->
-    FolderFun = fun (Input, TmpAcc) ->
-              case Input of
-                  {Index, Rules, Type, Identifier, Other} ->
-                  case is_scalar_type(Type) of
-                      true -> [Input | TmpAcc];
-                      false ->
-                      PossiblePaths =
-                          case string:tokens(Type,".") of
-                          [Type] ->
-                              all_possible_type_paths(Type, TypePath);
-                          FullPath ->
-                        % handle types of the form Foo.Bar which are absolute,
-                        % so we just convert to a type path and check it.
-                              [lists:reverse(FullPath)]
-                          end,
-                      RealPath =
-                          case find_type(PossiblePaths, AllPaths) of
-                          false ->
-                              case is_enum_type(Type, PossiblePaths, Enums) of
-                              {true,EnumType} ->
-                                  [EnumType];
-                              false ->
-                                  throw(["Unknown Type ", Type])
-                              end;
-                          ResultType ->
-                              ResultType
-                          end,
-                      [{Index, Rules, canonical_name(RealPath), Identifier, Other} | TmpAcc]
-                  end;
-                  _ -> TmpAcc
-              end
-        end,
-    FieldsOut = lists:foldl(FolderFun, [], Fields),
-    ExtendedOut = case Extended of
-        disallowed ->
-            disallowed;
-        _ ->
-            MidExtendOut = lists:foldl(FolderFun, [], Extended),
-            lists:reverse(MidExtendOut)
-    end,
-    Type = type_path_to_type(TypePath),
-    resolve_types(Tail, AllPaths, Enums, [{Type, lists:reverse(FieldsOut), ExtendedOut } | Acc]);
-resolve_types([], _, _, Acc) ->
+collect_full_messages([], Acc) -> 
     Acc.
 
-%% @hidden
-write_header_include_file(Basename, Messages) when is_list(Basename) ->
-    {ok, FileRef} = protobuffs_file:open(Basename, [write]),
-    write_header_include_file(FileRef, Messages),
-    protobuffs_file:close(FileRef);
-write_header_include_file(_FileRef, []) ->
-    ok;
-    write_header_include_file(FileRef, [{Name, Fields, Extends} | Tail]) ->
-    OutFields = [{string:to_lower(A), Optional, Default} || {_, Optional, _, A, Default} <- lists:keysort(1, Fields)],
-    DefName = string:to_upper(Name) ++ "_PB_H",
-    protobuffs_file:format(FileRef, "-ifndef(~s).~n-define(~s, true).~n", [DefName, DefName]),
-    protobuffs_file:format(FileRef, "-record(~s, {~n    ", [string:to_lower(Name)]),
-    WriteFields0 = generate_field_definitions(OutFields),
-    WriteFields = case Extends of
-                      disallowed -> WriteFields0;
-                      _ ->
-                          ExtenStr = "'$extensions' = dict:new()",
-                          WriteFields0 ++ [ExtenStr]
-                  end,
-    FormatString = string:join(["~s" || _ <- lists:seq(1, length(WriteFields))], ",~n    "),
-    protobuffs_file:format(FileRef, FormatString, WriteFields),
-    protobuffs_file:format(FileRef, "~n}).~n", []),
-    protobuffs_file:format(FileRef, "-endif.~n~n", []),
-    write_header_include_file(FileRef, Tail).
+resolve_types (Data) -> resolve_types (Data, Data, []).
+resolve_types ([{TypePath, Fields} | Tail], AllPaths, Acc) ->
+  FieldsOut = lists:foldl(
+      fun (Input, TmpAcc) ->
+          case Input of
+              {Index, Rules, Type, Identifier, RealType, Other} ->
+                case is_scalar_type (Type) of
+                  true -> [Input | TmpAcc];
+                  false ->
+                    PossiblePaths =
+                      case string:tokens (Type,".") of
+                        [Type] ->
+                          all_possible_type_paths (Type, TypePath);
+                        FullPath ->
+                          % handle types of the form Foo.Bar which are absolute,
+                          % so we just convert to a type path and check it.
+                          [lists:reverse (FullPath)]
+                      end,
+                    RealPath =
+                      case find_type (PossiblePaths, AllPaths) of
+                        false ->
+                          throw (["Unknown Type ", Type]);
+                        ResultType ->
+                          ResultType
+                      end,
+                    [{Index, Rules, type_path_to_type (RealPath), Identifier, RealType, Other} | TmpAcc]
+                end;
+              _ -> TmpAcc
+          end
+      end, [], Fields),
+  resolve_types (Tail, AllPaths,
+                 [ {type_path_to_type (TypePath), lists:reverse (FieldsOut) } | Acc]);
+resolve_types ([], _, Acc) ->
+    Acc.
 
-%% @hidden
-generate_field_definitions(Fields) ->
-    generate_field_definitions(Fields, []).
+write_header_include_file(Basename, Messages) ->
+    {ok, FileRef} = file:open(Basename ++ ".hrl", [write]),
+    [begin
+        OutFields = [string:to_lower(A) || {_, _, _, A, _, _} <- lists:keysort(1, Fields)],
+        io:format(FileRef, "-record(~s, {~s}).~n", [string:to_lower(Name), string:join(OutFields, ", ")])
+    end || {Name, Fields} <- Messages],
+    file:close(FileRef).
 
-%% @hidden
-generate_field_definitions([], Acc) ->
-    lists:reverse(Acc);
-generate_field_definitions([{Name, required, _} | Tail], Acc) ->
-    Head = lists:flatten(io_lib:format("~s = erlang:error({required, ~s})", [Name, Name])),
-    generate_field_definitions(Tail, [Head | Acc]);
-generate_field_definitions([{Name, _, none} | Tail], Acc) ->
-    Head = lists:flatten(io_lib:format("~s", [Name])),
-    generate_field_definitions(Tail, [Head | Acc]);
-generate_field_definitions([{Name, _, Default} | Tail], Acc) ->
-    Head = lists:flatten(io_lib:format("~s = ~p", [Name, Default])),
-    generate_field_definitions(Tail, [Head | Acc]).
-
-%% @hidden
-% handle ["symbol"]
-atomize([String]) when is_list(String) ->
-    atomize(String);
-% handle ["symbol", "package_symbol"]
-atomize([String|[_Rest]]) when is_list(String) ->
-    atomize(String);
 atomize(String) ->
     list_to_atom(string:to_lower(String)).
 
-%% @hidden
 replace_atom(Find, Find, Replace) -> Replace;
+
 replace_atom(Tuple, Find, Replace) when is_tuple(Tuple) ->
     list_to_tuple([replace_atom(Term, Find, Replace) || Term <- tuple_to_list(Tuple)]);
+
 replace_atom(List, Find, Replace) when is_list(List) ->
     [replace_atom(Term, Find, Replace) || Term <- List];
+
 replace_atom(Other, _Find, _Replace) ->
     Other.
 
-%% @hidden
-is_scalar_type("double") -> true;
-is_scalar_type("float") -> true;
-is_scalar_type("int32") -> true;
-is_scalar_type("int64") -> true;
-is_scalar_type("uint32") -> true;
-is_scalar_type("uint64") -> true;
-is_scalar_type("sint32") -> true;
-is_scalar_type("sint64") -> true;
-is_scalar_type("fixed32") -> true;
-is_scalar_type("fixed64") -> true;
-is_scalar_type("sfixed32") -> true;
-is_scalar_type("sfixed64") -> true;
-is_scalar_type("bool") -> true;
-is_scalar_type("string") -> true;
-is_scalar_type("bytes") -> true;
-is_scalar_type(_) -> false.
+is_scalar_type ("double") -> true;
+is_scalar_type ("float") -> true;
+is_scalar_type ("int32") -> true;
+is_scalar_type ("int64") -> true;
+is_scalar_type ("uint32") -> true;
+is_scalar_type ("uint64") -> true;
+is_scalar_type ("sint32") -> true;
+is_scalar_type ("sint64") -> true;
+is_scalar_type ("fixed32") -> true;
+is_scalar_type ("fixed64") -> true;
+is_scalar_type ("sfixed32") -> true;
+is_scalar_type ("sfixed64") -> true;
+is_scalar_type ("bool") -> true;
+is_scalar_type ("string") -> true;
+is_scalar_type ("bytes") -> true;
+is_scalar_type (_) -> false.
 
-%% @hidden
-is_enum_type(_Type, [], _Enums) ->
-    false;
-is_enum_type(Type, [TypePath|Paths], Enums) ->
-    TypeFromPath = type_path_to_type(TypePath),
-    case is_enum_type(TypeFromPath, Enums) of
-      true ->
-            {true,TypePath};
-      false ->
-            is_enum_type(Type, Paths, Enums)
-    end.
-is_enum_type(Type, Enums) ->
-    lists:any(fun(Enum) ->
-        Types = element(2, Enum),
-        lists:member(Type, Types)
-    end, Enums).
-
-%% @hidden
 sublists(List) when is_list(List) ->
-    sublists(List,[]).
+  sublists(List,[]).
 sublists([],Acc) ->
-    [ [] | Acc ];
+  [ [] | Acc ];
 sublists(List,Acc) ->
-    sublists(tl(List), [ List | Acc ]).
+  sublists (tl (List), [ List | Acc ]).
 
-%% @hidden
-all_possible_type_paths(Type, TypePaths) ->
-    all_possible_type_paths(Type, TypePaths, []).
+all_possible_type_paths (Type, TypePath) ->
+  lists:foldl (fun (TypeSuffix, AccIn) ->
+                 [[Type | TypeSuffix] | AccIn]
+               end,
+               [],
+               sublists (TypePath)).
 
-all_possible_type_paths(_Type, [], Acc) ->
-    lists:reverse(lists:flatten(Acc));
-all_possible_type_paths(Type, [TypePath | Tail], Acc) ->
-    TypePath0 = tuple_to_list(TypePath),
-    Head = lists:foldl(fun (TypeSuffix, AccIn) ->
-             [list_to_tuple([Type | TypeSuffix]) | AccIn]
-         end,
-         [],
-         sublists(TypePath0)),
-    all_possible_type_paths(Type, Tail, [Head | Acc]).
+find_type ([], _KnownTypes) ->
+  false;
+find_type ([Type | TailTypes], KnownTypes) ->
+  case lists:keysearch (Type, 1, KnownTypes) of
+    false ->
+      find_type (TailTypes, KnownTypes);
+    {value, {RealType, _}} ->
+      RealType
+  end.
 
-%% @hidden
-find_type([], _KnownTypes) ->
-    false;
-find_type([Type | TailTypes], KnownTypes) when is_list(Type) ->
-    find_type([list_to_tuple(Type) | TailTypes], KnownTypes);
-find_type([Type | TailTypes], KnownTypes) ->
-    FilterFun = fun(KnownType) ->
-        lists:member(Type, element(1, KnownType))
-    end,
-    case lists:filter(FilterFun, KnownTypes) of
-        [] ->
-            find_type(TailTypes, KnownTypes);
-        [{RealType, _, _} | _] ->
-            RealType
-    end.
+type_path_to_type (TypePath) ->
+  string:join (lists:reverse (TypePath), "_").
 
-%% @hidden
-canonical_name([TypePath | _]) ->
-    % yes, we're assuming the first name in the list is the most
-    % cannonical name.
-    type_path_to_type(TypePath).
-
-canonize_names(Messages) ->
-    canonize_names(Messages, []).
-
-canonize_names([], Acc) ->
-    lists:reverse(Acc);
-canonize_names([Enum | Tail], Acc) when element(1, Enum) == enum ->
-    Name = canonical_name(element(2, Enum)),
-    Enum0 = setelement(2, Enum, Name),
-    canonize_names(Tail, [Enum0 | Acc]);
-canonize_names([Msg | Tail], Acc) ->
-    Name = canonical_name(element(1, Msg)),
-    Msg0 = setelement(1,Msg,Name),
-    canonize_names(Tail, [Msg0 | Acc]).
-
-%% @hidden
-type_path_to_type([[Name|Tuple]]) when is_tuple(Tuple) ->
-    type_path_to_type([Name | tuple_to_list(Tuple)]);
-type_path_to_type(TypePath) when is_tuple(TypePath) ->
-    type_path_to_type(tuple_to_list(TypePath));
-type_path_to_type(TypePath) ->
-    case is_list(hd(TypePath)) of
-        true ->
-            string:join(lists:reverse(TypePath), "_");
-        false ->
-            TypePath
-    end.


### PR DESCRIPTION
## optimize execute efficiency
### 1.  get record name
#### before:
```erlang
 [RecName | _] = tuple_to_list(Data)  
```
#### after :
```erlang
erlang:element(1,Data) 
```
### 2. arguments match 
#### before:
```erlang
test(Bytes) when is_binary(Bytes) ->  ok. 
```
#### after:
```erlang
test(<< Bytes/binary>>) ->      ok. 
```
### 3. case clause match 
#### before:
```erlang
case Data of
   {C, double} -> ok;
   {C, int} -> ok;
   {C, string} -> ok;
   _ -> ok
end
```
#### after:
```erlang
case Data of
   {double, C} -> ok;
   {int, C} -> ok;
   {string, C} -> ok;
   _ -> ok
end
```
## optimize call pattern
### before:
```erlang
test_pb:encode_person(Person).
test_pb:decode_person(Data). 
```
### after:
```erlang
test_pb:encode(Person).
test_pb:decode(person, Data).
```
so, you can map the protocols, encode/decode them in the same way. by the way, the old pattern is keep
## resolve empty protocol warning
```proto
message tos{
}
```
```shell
2> test_pb:encode_tos(#tos{}). 
<<>> 
3> c(test_pb). 
src/test_pb.erl:33: Warning: variable 'Record' is unused
{ok,test_pb}
```