### PR TITLE
Fix a warning in pokemon_pb.erl when compiling with Erlang OTP 18.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {deps,[
-       {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}}
+       {meck, "0.8.3", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.3"}}}
       ]}.
 
 {clean_files, ["*~","**/*~","**/*.beam","logs/*","test/Emakefile"]}.

--- a/src/pokemon_pb.erl
+++ b/src/pokemon_pb.erl
@@ -225,26 +225,26 @@ decode_extensions(Types, [{Fnum, Bytes} | Tail], Acc) ->
             {Value1, Rest1} =
                 case lists:member(is_record, Opts) of
                     true ->
-                        {{FNum, V}, R} = protobuffs:decode(Bytes, bytes),
+                        {{Fnum, V}, R} = protobuffs:decode(Bytes, bytes),
                         RecVal = decode(Type, V),
                         {RecVal, R};
                     false ->
                         case lists:member(repeated_packed, Opts) of
                             true ->
-                                {{FNum, V}, R} = protobuffs:decode_packed(Bytes, Type),
+                                {{Fnum, V}, R} = protobuffs:decode_packed(Bytes, Type),
                                 {V, R};
                             false ->
-                                {{FNum, V}, R} = protobuffs:decode(Bytes, Type),
+                                {{Fnum, V}, R} = protobuffs:decode(Bytes, Type),
                                 {unpack_value(V, Type), R}
                         end
                 end,
             case lists:member(repeated, Opts) of
                 true ->
-                    case lists:keytake(FNum, 1, Acc) of
-                        {value, {FNum, Name, List}, Acc1} ->
-                            decode(Rest1, Types, [{FNum, Name, lists:reverse([int_to_enum(Type,Value1)|lists:reverse(List)])}|Acc1]);
+                    case lists:keytake(Fnum, 1, Acc) of
+                        {value, {Fnum, Name, List}, Acc1} ->
+                            decode(Rest1, Types, [{Fnum, Name, lists:reverse([int_to_enum(Type,Value1)|lists:reverse(List)])}|Acc1]);
                         false ->
-                            decode(Rest1, Types, [{FNum, Name, [int_to_enum(Type,Value1)]}|Acc])
+                            decode(Rest1, Types, [{Fnum, Name, [int_to_enum(Type,Value1)]}|Acc])
                     end;
                 false ->
                     [{Fnum, {optional, int_to_enum(Type,Value1), Type, Opts}} | Acc]


### PR DESCRIPTION
Compiling riak-erlang-client with Erlang OTP 18.0 fails on
```
Compiling src/riak_yokozuna.proto                                                  
                                                                                   
=INFO REPORT==== 17-Jul-2015::09:58:47 ===                                         
Writing header file to "riak_yokozuna_pb.hrl"                                      
ERROR: compile failed while processing /tmp/riak_pb: {'EXIT',                      
    {{badmatch,                                                                    
         {error,[],                                                                
             [{"src/riak_yokozuna_pb.erl",                                         
               [{244,erl_lint,{exported_var,'FNum',{'case',226}}}]}]}},            
     [{protobuffs_compile,output,4,                                                
          [{file,"src/protobuffs_compile.erl"},{line,147}]},                       
      {rebar_protobuffs_compiler,compile_each,2,                                   
          [{file,"src/rebar_protobuffs_compiler.erl"},{line,111}]},                
      {rebar_core,run_modules,4,[{file,"src/rebar_core.erl"},{line,493}]},         
      {rebar_core,execute,6,[{file,"src/rebar_core.erl"},{line,418}]},             
      {rebar_core,maybe_execute,8,[{file,"src/rebar_core.erl"},{line,302}]},       
      {rebar_core,process_dir1,7,[{file,"src/rebar_core.erl"},{line,261}]},        
      {rebar_core,process_commands,2,[{file,"src/rebar_core.erl"},{line,93}]},     
      {rebar,main,1,[{file,"src/rebar.erl"},{line,58}]}]}}   
```
The warning on exported variable 'FNum' originates from pokemon_pb.erl when compiled with Erlang OTP 18.0. Previous compiler version did not generate an warning.