### PR TITLE
Fixes required for OTP 18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {deps,[
-       {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}}
+       {meck, ".*", {git, "git://github.com/basho/meck.git", {tag, "0.8.3"}}}
       ]}.
 
 {clean_files, ["*~","**/*~","**/*.beam","logs/*","test/Emakefile"]}.

--- a/src/pokemon_pb.erl
+++ b/src/pokemon_pb.erl
@@ -219,9 +219,9 @@ decode_extensions(Record) ->
 
 decode_extensions(_Types, [], Acc) ->
     dict:from_list(Acc);
-decode_extensions(Types, [{Fnum, Bytes} | Tail], Acc) ->
-    NewAcc = case lists:keyfind(Fnum, 1, Types) of
-        {Fnum, Name, Type, Opts} ->
+decode_extensions(Types, [{FNum, Bytes} | Tail], Acc) ->
+    NewAcc = case lists:keyfind(FNum, 1, Types) of
+        {FNum, Name, Type, Opts} ->
             {Value1, Rest1} =
                 case lists:member(is_record, Opts) of
                     true ->
@@ -247,10 +247,10 @@ decode_extensions(Types, [{Fnum, Bytes} | Tail], Acc) ->
                             decode(Rest1, Types, [{FNum, Name, [int_to_enum(Type,Value1)]}|Acc])
                     end;
                 false ->
-                    [{Fnum, {optional, int_to_enum(Type,Value1), Type, Opts}} | Acc]
+                    [{FNum, {optional, int_to_enum(Type,Value1), Type, Opts}} | Acc]
             end;
         false ->
-            [{Fnum, Bytes} | Acc]
+            [{FNum, Bytes} | Acc]
     end,
     decode_extensions(Types, Tail, NewAcc).
 


### PR DESCRIPTION
Uses newer `meck` version and includes a fix in variable names (OTP18 has more strict checks).

We need this for https://github.com/esl/MongooseIM/pull/497 and Travis build that uses it is here: https://travis-ci.org/esl/MongooseIM/builds/78350720