### PR TITLE
unit64 is a typo still in the spec

### DIFF
--- a/src/protobuffs.erl
+++ b/src/protobuffs.erl
@@ -50,7 +50,7 @@
 	?TYPE_START_GROUP | ?TYPE_END_GROUP | ?TYPE_32BIT.
 
 -type field_type() :: bool | enum | int32 | uint32 | int64 |
-		      unit64 | sint32 | sint64 | fixed32 |
+		      uint64 | sint32 | sint64 | fixed32 |
 		      sfixed32 | fixed64 | sfixed64 | string |
 		      bytes | float | double.
 


### PR DESCRIPTION
unit64 was a typo introduced really early in the code, and should have been uint64. Most uses have been fixed but the spec is still wrong. This has not been caught before cause decoding actually has a catch all so you can write anything and it will be handled as a uint64 in a varint anyway.

This branch fixes the last typo.
