### PR TITLE
Fix variable exported from case for R18.1 support

### DIFF
--- a/src/pokemon_pb.erl
+++ b/src/pokemon_pb.erl
@@ -219,9 +219,9 @@ decode_extensions(Record) ->
 
 decode_extensions(_Types, [], Acc) ->
     dict:from_list(Acc);
-decode_extensions(Types, [{Fnum, Bytes} | Tail], Acc) ->
-    NewAcc = case lists:keyfind(Fnum, 1, Types) of
-        {Fnum, Name, Type, Opts} ->
+decode_extensions(Types, [{FNum, Bytes} | Tail], Acc) ->
+    NewAcc = case lists:keyfind(FNum, 1, Types) of
+        {FNum, Name, Type, Opts} ->
             {Value1, Rest1} =
                 case lists:member(is_record, Opts) of
                     true ->
@@ -247,10 +247,10 @@ decode_extensions(Types, [{Fnum, Bytes} | Tail], Acc) ->
                             decode(Rest1, Types, [{FNum, Name, [int_to_enum(Type,Value1)]}|Acc])
                     end;
                 false ->
-                    [{Fnum, {optional, int_to_enum(Type,Value1), Type, Opts}} | Acc]
+                    [{FNum, {optional, int_to_enum(Type,Value1), Type, Opts}} | Acc]
             end;
         false ->
-            [{Fnum, Bytes} | Acc]
+            [{FNum, Bytes} | Acc]
     end,
     decode_extensions(Types, Tail, NewAcc).
 


### PR DESCRIPTION
That compile time warning make it impossible to compile proto files under Erlang R18.

After approving this commit, it is needed to tag it. It can be tagged either as "0.8.1p6" or "0.8.2" so that it can be reused / referenced directly in other rebar.config file (riak_pb will need this).