### PR TITLE
OTP 18 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ logs
 deps
 .eunit
 .directory
+.rebar
 src/protobuffs_parser.erl
 src/protobuffs_scanner.erl
 erl_crash.dump

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {clean_files, ["*~","**/*~","**/*.beam","logs/*","test/Emakefile"]}.
 
-{cover_enabled, true}.
+{cover_enabled, false}.
 
 {eunit_opts, [verbose,
               {report, {eunit_surefire, [{dir, "."}]}}]}.

--- a/src/pokemon_pb.erl
+++ b/src/pokemon_pb.erl
@@ -219,9 +219,9 @@ decode_extensions(Record) ->
 
 decode_extensions(_Types, [], Acc) ->
     dict:from_list(Acc);
-decode_extensions(Types, [{Fnum, Bytes} | Tail], Acc) ->
-    NewAcc = case lists:keyfind(Fnum, 1, Types) of
-        {Fnum, Name, Type, Opts} ->
+decode_extensions(Types, [{FNum, Bytes} | Tail], Acc) ->
+    NewAcc = case lists:keyfind(FNum, 1, Types) of
+        {FNum, Name, Type, Opts} ->
             {Value1, Rest1} =
                 case lists:member(is_record, Opts) of
                     true ->
@@ -247,10 +247,10 @@ decode_extensions(Types, [{Fnum, Bytes} | Tail], Acc) ->
                             decode(Rest1, Types, [{FNum, Name, [int_to_enum(Type,Value1)]}|Acc])
                     end;
                 false ->
-                    [{Fnum, {optional, int_to_enum(Type,Value1), Type, Opts}} | Acc]
+                    [{FNum, {optional, int_to_enum(Type,Value1), Type, Opts}} | Acc]
             end;
         false ->
-            [{Fnum, Bytes} | Acc]
+            [{FNum, Bytes} | Acc]
     end,
     decode_extensions(Types, Tail, NewAcc).
 


### PR DESCRIPTION
See original PR #88 

Thank you @mremond

I'm wondering what's up with rebar + OTP 18.1 because I get this error
when code coverage is enabled:

```
module 'protobuffs_compile'
  module 'protobuffs_compile_tests'
undefined
*unexpected termination of test process*
::{compile_forms,{error,[{"cover.erl",
                          [{77,erl_lint,
                            {undefined_function,{compile_beam,...}}}]}],
                        []}}
```

`cover:compile_beam` is present ... so I'm not sure.

This is why I disabled code coverage. The coverage output is not used
to determine test success so it is safe to disable for now.