### PR TITLE
generate int to int mapping for enums :sun_with_face:

### DIFF
--- a/src/protobuffs_compile.erl
+++ b/src/protobuffs_compile.erl
@@ -565,11 +565,22 @@ filter_to_record_clause({MsgName, _, Extends}, {clause,L,[_Param1,Param2],Guards
 expand_enum_to_int_function([], Line, Clause) ->
     {function,Line,enum_to_int,2,[Clause]};
 expand_enum_to_int_function(Enums, Line, Clause) ->
-    {function,Line,enum_to_int,2,[filter_enum_to_int_clause(Enum, Clause) || Enum <- Enums]}.
+    {function,Line,enum_to_int,2,filter_enum_to_int_clauses(Enums, Clause)}.
+
+%% @hidden
+filter_enum_to_int_clauses([], _Clause) ->
+    [];
+filter_enum_to_int_clauses([Enum | RestEnums], Clause) ->
+    [filter_enum_to_int_clause(Enum, Clause),
+     filter_enum_int_to_int_clause(Enum, Clause) | filter_enum_to_int_clauses(RestEnums, Clause)].
 
 %% @hidden
 filter_enum_to_int_clause({enum,EnumTypeName,IntValue,EnumValue}, {clause,L,_Args,Guards,_}) ->
     {clause,L,[{atom,L,atomize(EnumTypeName)},{atom,L,EnumValue}],Guards,[{integer,L,IntValue}]}.
+
+%% @hidden
+filter_enum_int_to_int_clause({enum,EnumTypeName,IntValue,_EnumValue}, {clause,L,_Args,Guards,_}) ->
+    {clause,L,[{atom,L,atomize(EnumTypeName)},{integer,L,IntValue}],Guards,[{integer,L,IntValue}]}.
 
 %% @hidden
 expand_int_to_enum_function([], Line, Clause) ->

--- a/test/protobuffs_compile_tests.erl
+++ b/test/protobuffs_compile_tests.erl
@@ -83,4 +83,5 @@ parse_enum_test() ->
      [?_assertMatch(ok,
         (protobuffs_compile:scan_string("message Dummy { enum Type { A = 10}}", "dummy", [{compile_flags, [warnings_as_errors]}]))),
       ?_assertMatch(10, dummy_pb:enum_to_int(dummy_type, 'A')),
+      ?_assertMatch(10, dummy_pb:enum_to_int(dummy_type, 10)),
       ?_assertMatch('A', dummy_pb:int_to_enum(dummy_type, 10))]}.


### PR DESCRIPTION
this is useful when applications sometimes get the integers already
and hence no need to convert them back to enum atom names to allow protobuf:encode functioning.

use the `enum QAGMediaRating` in http://docs.openx.com/resources/ssrtb.proto_v21.txt as proto example:

```proto
message Content {
  // QAG Media Ratings. Integer values are from the OpenRTB 2.3 spec, Section 5.15.
  enum QAGMediaRating {
    all_audiences    = 1;
    everyone_over_12 = 2;
    mature_audiences = 3;
  }
  optional QAGMediaRating rating = 1;
}
```

it will generate this code difference
```diff
--- ssrtb.proto_v21.txt_pb.erl.orig     2015-11-14 14:01:25.159020711 -0800
+++ ssrtb.proto_v21.txt_pb.erl  2015-11-14 15:12:23.636304631 -0800
@@ -770,42 +770,68 @@ pack(FNum, _, Data, Type, _) when is_ato
     protobuffs:encode(FNum, enum_to_int(Type, Data), enum).

 enum_to_int(content_qagmediarating, mature_audiences) ->
     3;
+enum_to_int(content_qagmediarating, 3) -> 3;
 enum_to_int(content_qagmediarating, everyone_over_12) ->
     2;
+enum_to_int(content_qagmediarating, 2) -> 2;
 enum_to_int(content_qagmediarating, all_audiences) -> 1;
+enum_to_int(content_qagmediarating, 1) -> 1;

```
