### PR TITLE
allow all 0.8.x meck versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {deps,[
-       {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}}
+       {meck, "0.8.*", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}}
       ]}.
 
 {clean_files, ["*~","**/*~","**/*.beam","logs/*","test/Emakefile"]}.


### PR DESCRIPTION
Strict version checking causes `version_mismatch` errors when a project depending on basho/erlang_protobuffs (especially not directly like esl/MongooseIM) uses other version of meck.