### PR TITLE
Quote reserved words instead of prefixing them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=622369a511690ee1a7fe54c44eebb57dc8e24b5f
   email: eng@basho.com
 otp_release:
-  - R16B03
+  - 18.3
   - 17.5
-  - 18.1
+  - R16B03
+  - R15B03

--- a/src/protobuffs_parser.yrl
+++ b/src/protobuffs_parser.yrl
@@ -45,12 +45,10 @@ g_default -> '$empty' : none.
 g_default -> '[' g_var '=' g_value ']' 				: {'$2', '$4'}.
 
 Erlang code.
-safe_string(A) -> make_safe(atom_to_list(A)).
-
-make_safe(String) ->
-  case erl_scan:reserved_word(list_to_atom(String)) of 
-    true -> "pb_"++String;
-    false -> String
+safe_string(Atom) ->
+  case erl_scan:reserved_word(Atom) of
+    true -> "'" ++ atom_to_list(Atom) ++ "'";
+    false -> atom_to_list(Atom)
   end.
 
 unwrap({_,_,V}) -> V;

--- a/test/protobuffs_parser_tests.erl
+++ b/test/protobuffs_parser_tests.erl
@@ -23,10 +23,15 @@ import_test_() ->
     parse_test(String, Expected).
 
 message_test_() ->
-    String = "message Test { required string name "
-	     "= 1; }",
+    String = "message Test { required string name = 1; }",
     Expected = [{message, "Test",
 		 [{1, required, "string", "name", none}]}],
+    parse_test(String, Expected).
+
+message_reserved_word_test_() ->
+    String = "message Test { required string case = 1; }",
+    Expected = [{message, "Test",
+		 [{1, required, "string", "'case'", none}]}],
     parse_test(String, Expected).
 
 message_default_test_() ->


### PR DESCRIPTION
This fixes issues using R15 and the Riak TS messages, specifically those that use the R15 keyword `query`

See basho/riak_pb#205