### PR TITLE
ignore dialyzer no-match warnings on pokemon_pb

### DIFF
--- a/src/pokemon_pb.erl
+++ b/src/pokemon_pb.erl
@@ -31,6 +31,8 @@
 -export([int_to_enum/2, enum_to_int/2]).
 -record(pikachu, {abc, def, '$extensions' = dict:new()}).
 
+-dialyzer(no_match).
+
 %% ENCODE
 encode([]) ->
     [];


### PR DESCRIPTION
Dialyzer complains about clauses that can never match in the generated
code for a very simple protobuf definition I'm using. I'd like to keep
dialyzer in the default make target, so I'm adding an ignore directive
for that warning to pokemon_pb, which is where the generated code
comes from.

Example warnings:
```
  47: Guard test is_list(Records::tuple()) can never succeed
  74: The pattern <_, 'repeated_packed', 'undefined', _, _> can never match the type <1 | 2 | 3 | 4 | 5 | 6 | 7 | 2046 | 2047,'optional' | 'repeated',_,atom(),[any()]>
  75: The pattern <_, 'repeated_packed', [], _, _> can never match the type <1 | 2 | 3 | 4 | 5 | 6 | 7 | 2046 | 2047,'optional' | 'repeated',_,atom(),[any()]>
  77: The pattern <FNum, 'required', 'undefined', Type, _> can never match the type <1 | 2 | 3 | 4 | 5 | 6 | 7 | 2046 | 2047,'optional' | 'repeated',_,atom(),[any()]>
  86: The pattern <FNum, 'repeated_packed', Data, Type, _> can never match the type <1 | 2 | 3 | 4 | 5 | 6 | 7 | 2046 | 2047,'optional' | 'repeated',_,atom(),[any()]>
 222: The pattern <Types, [{FNum, Bytes} | Tail], Acc> can never match the type <_,[],[{_,_}]>
```